### PR TITLE
replacing npm with yarn in semantic release config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,15 +31,15 @@ jobs:
         run: yarn lint
       - name: Build
         run: yarn build
+      - name: Replace Action
+        uses: datamonsters/replace-action@v2
+        with:
+          files: ./.yarnrc.yml
+          replacements: NPM_TOKEN=${{secrets.npm_token}}
       - name: Release
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
-      # - name: Replace Action
-      #   uses: datamonsters/replace-action@v2
-      #   with:
-      #     files: ./.yarnrc.yml
-      #     replacements: NPM_TOKEN=${{secrets.npm_token}}
       # - name: Publish beta version to NPM (uses package.json version)
       #   run: yarn npm publish --tag stable --access public

--- a/release.config.js
+++ b/release.config.js
@@ -11,7 +11,7 @@ module.exports = {
                 changelogFile: 'CHANGELOG.md'
             }
         ],
-        '@semantic-release/npm',
+        '@semantic-release-yarn',
         '@semantic-release/github',
         [
             '@semantic-release/git',


### PR DESCRIPTION
:green_heart: replacing npm with yarn in semantic release config