### PR TITLE
fixing a typo on yarn package used in semantic release config

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -11,7 +11,7 @@ module.exports = {
                 changelogFile: 'CHANGELOG.md'
             }
         ],
-        '@semantic-release-yarn',
+        'semantic-release-yarn',
         '@semantic-release/github',
         [
             '@semantic-release/git',


### PR DESCRIPTION
:pencil2: fixing a typo on yarn package used in semantic release config

closes #8 