### PR TITLE
Removing subheaders from lists

### DIFF
--- a/src/components/ChangeEvents/ChangeEvents.tsx
+++ b/src/components/ChangeEvents/ChangeEvents.tsx
@@ -16,7 +16,7 @@
 
 // eslint-disable-next-line @backstage/no-undeclared-imports
 import React, { useEffect } from 'react';
-import { List, ListSubheader } from '@material-ui/core';
+import { List } from '@material-ui/core';
 import { ChangeEventListItem } from './ChangeEventListItem';
 import { ChangeEventEmptyState } from './ChangeEventEmptyState';
 import useAsyncFn from 'react-use/lib/useAsyncFn';

--- a/src/components/ChangeEvents/ChangeEvents.tsx
+++ b/src/components/ChangeEvents/ChangeEvents.tsx
@@ -61,7 +61,7 @@ export const ChangeEvents = ({ serviceId, refreshEvents }: Props) => {
   }
 
   return (
-    <List dense subheader={<ListSubheader>CHANGE EVENTS</ListSubheader>}>
+    <List dense>
       {changeEvents!.map((changeEvent, index) => (
         <ChangeEventListItem
           key={changeEvent.id + index}

--- a/src/components/Incident/Incidents.tsx
+++ b/src/components/Incident/Incidents.tsx
@@ -63,7 +63,7 @@ export const Incidents = ({ serviceId, refreshIncidents }: Props) => {
   }
 
   return (
-    <List dense subheader={<ListSubheader>INCIDENTS</ListSubheader>}>
+    <List dense>
       {incidents!.map((incident, index) => (
         <IncidentListItem key={incident.id + index} incident={incident} />
       ))}

--- a/src/components/Incident/Incidents.tsx
+++ b/src/components/Incident/Incidents.tsx
@@ -15,7 +15,7 @@
  */
 // eslint-disable-next-line @backstage/no-undeclared-imports
 import React, { useEffect } from 'react';
-import { List, ListSubheader } from '@material-ui/core';
+import { List } from '@material-ui/core';
 import { IncidentListItem } from './IncidentListItem';
 import { IncidentsEmptyState } from './IncidentEmptyState';
 import useAsyncFn from 'react-use/lib/useAsyncFn';


### PR DESCRIPTION
Adding some consistency to the UI.

- :lipstick: removing subheaders from lists to avoid title duplication