### PR TITLE
updating trigger to push to version and package to be generated and published. 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,12 @@
 name: Release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
+    branches:
+      - main
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Semantic Release cannot generate new package from PR. It needs to run on "push".