### PR TITLE
fix: list only oncall users in plugin

### DIFF
--- a/dev/mockPagerDutyApi.ts
+++ b/dev/mockPagerDutyApi.ts
@@ -39,6 +39,7 @@ export const mockPagerDutyApi: PagerDutyApi = {
             email: 'email@email.com',
             html_url: 'http://user',
             name: 'some-user',
+            avatar_url: 'http://avatar',
           },
         },
       },
@@ -61,6 +62,7 @@ export const mockPagerDutyApi: PagerDutyApi = {
             email: 'email@email.com',
             html_url: 'http://user',
             name: 'some-user',
+            avatar_url: 'http://avatar',
           },
         },
       },
@@ -130,6 +132,7 @@ export const mockPagerDutyApi: PagerDutyApi = {
           html_url: 'http://assignee',
           summary: 'summary',
           email: 'email@email.com',
+          avatar_url: 'http://avatar',
         },
         escalation_level: escalation,
       };

--- a/dev/mockPagerDutyApi.ts
+++ b/dev/mockPagerDutyApi.ts
@@ -139,7 +139,7 @@ export const mockPagerDutyApi: PagerDutyApi = {
     };
 
     return {
-      oncalls: [oncall('Jane Doe', 1), oncall('John Doe', 2)],
+      oncalls: [oncall('Jane Doe', 1), oncall('John Doe', 2), oncall('James Doe', 1)],
     };
   },
 

--- a/dev/mockPagerDutyApi.ts
+++ b/dev/mockPagerDutyApi.ts
@@ -124,10 +124,10 @@ export const mockPagerDutyApi: PagerDutyApi = {
   },
 
   async getOnCallByPolicyId() {
-    const oncall = (name: string, escalation: number) => {
+    const oncall = (id: string, name: string, escalation: number) => {
       return {
         user: {
-          id: '123',
+          id: id,
           name: name,
           html_url: 'http://assignee',
           summary: 'summary',
@@ -139,7 +139,7 @@ export const mockPagerDutyApi: PagerDutyApi = {
     };
 
     return {
-      oncalls: [oncall('Jane Doe', 1), oncall('John Doe', 2), oncall('James Doe', 1)],
+      oncalls: [oncall('1', 'Jane Doe', 1), oncall('2', 'John Doe', 2), oncall('3', 'James Doe', 1)],
     };
   },
 

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -40,6 +40,7 @@ const user: PagerDutyUser = {
   summary: 'person1',
   email: 'person1@example.com',
   html_url: 'http://a.com/id1',
+  avatar_url: 'http://a.com/id1/avatar',
 };
 
 const service: PagerDutyService = {

--- a/src/components/EntityPagerDutyCard/index.test.tsx
+++ b/src/components/EntityPagerDutyCard/index.test.tsx
@@ -79,6 +79,7 @@ const user: PagerDutyUser = {
   summary: 'person1',
   email: 'person1@example.com',
   html_url: 'http://a.com/id1',
+  avatar_url: 'http://a.com/id1/avatar',
 };
 
 const service: PagerDutyService = {

--- a/src/components/Escalation/Escalation.test.tsx
+++ b/src/components/Escalation/Escalation.test.tsx
@@ -59,7 +59,9 @@ describe('Escalation', () => {
               email: 'person1@example.com',
               html_url: 'http://a.com/id1',              
             } as PagerDutyUser,
+            escalation_level: 1,
           },
+          
         ],
       }));
 
@@ -77,6 +79,50 @@ describe('Escalation', () => {
     expect(mockPagerDutyApi.getOnCallByPolicyId).toHaveBeenCalledWith('abc');
   });
 
+  it("Renders only user(s) in escalation level 1", async () => {
+    mockPagerDutyApi.getOnCallByPolicyId = jest
+      .fn()
+      .mockImplementationOnce(async () => ({
+        oncalls: [
+          {
+            user: {
+              name: "person1",
+              id: "p1",
+              summary: "person1",
+              email: "person1@example.com",
+              html_url: "http://a.com/id1",
+            } as PagerDutyUser,
+            escalation_level: 1,
+          },
+          {
+            user: {
+              name: "person2",
+              id: "p2",
+              summary: "person2",
+              email: "person2@example.com",
+              html_url: "http://a.com/id2",
+            } as PagerDutyUser,
+            escalation_level: 2,
+          },
+        ],
+      }));
+
+    const { getByText, queryByTestId, queryByText } = render(
+      wrapInTestApp(
+        <ApiProvider apis={apis}>
+          <EscalationPolicy policyId="abc" />
+        </ApiProvider>
+      )
+    );
+    await waitFor(() => !queryByTestId("progress"));
+
+    expect(getByText("person1")).toBeInTheDocument();
+    expect(getByText("person1@example.com")).toBeInTheDocument();
+    expect(queryByText("person2")).not.toBeInTheDocument();
+    expect(queryByText("person2@example.com")).not.toBeInTheDocument();
+    expect(mockPagerDutyApi.getOnCallByPolicyId).toHaveBeenCalledWith("abc");
+  });
+
   it("Renders a user with profile picture", async () => {
     mockPagerDutyApi.getOnCallByPolicyId = jest
       .fn()
@@ -92,6 +138,7 @@ describe('Escalation', () => {
               avatar_url:
                 "https://gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y",
             } as PagerDutyUser,
+            escalation_level: 1,
           },
         ],
       }));

--- a/src/components/Escalation/Escalation.test.tsx
+++ b/src/components/Escalation/Escalation.test.tsx
@@ -61,7 +61,6 @@ describe('Escalation', () => {
             } as PagerDutyUser,
             escalation_level: 1,
           },
-          
         ],
       }));
 
@@ -77,6 +76,60 @@ describe('Escalation', () => {
     expect(getByText('person1')).toBeInTheDocument();
     expect(getByText('person1@example.com')).toBeInTheDocument();
     expect(mockPagerDutyApi.getOnCallByPolicyId).toHaveBeenCalledWith('abc');
+  });
+
+  it("Renders a list of users without duplicates", async () => {
+    mockPagerDutyApi.getOnCallByPolicyId = jest
+      .fn()
+      .mockImplementationOnce(async () => ({
+        oncalls: [
+          {
+            user: {
+              name: "person1",
+              id: "p1",
+              summary: "person1",
+              email: "person1@example.com",
+              html_url: "http://a.com/id1",
+            } as PagerDutyUser,
+            escalation_level: 1,
+          },
+          {
+            user: {
+              name: "person2",
+              id: "p2",
+              summary: "person2",
+              email: "person2@example.com",
+              html_url: "http://a.com/id2",
+            } as PagerDutyUser,
+            escalation_level: 1,
+          },
+          {
+            user: {
+              name: "person2",
+              id: "p2",
+              summary: "person2",
+              email: "person2@example.com",
+              html_url: "http://a.com/id2",
+            } as PagerDutyUser,
+            escalation_level: 1,
+          },
+        ],
+      }));
+
+    const { getByText, queryByTestId, queryAllByText } = render(
+      wrapInTestApp(
+        <ApiProvider apis={apis}>
+          <EscalationPolicy policyId="abc" />
+        </ApiProvider>
+      )
+    );
+    await waitFor(() => !queryByTestId("progress"));
+
+    expect(getByText("person1")).toBeInTheDocument();
+    expect(getByText("person1@example.com")).toBeInTheDocument();
+    expect(queryAllByText("person2").length).toBe(1);
+    expect(queryAllByText("person2@example.com").length).toBe(1);
+    expect(mockPagerDutyApi.getOnCallByPolicyId).toHaveBeenCalledWith("abc");
   });
 
   it("Renders only user(s) in escalation level 1", async () => {

--- a/src/components/Escalation/Escalation.test.tsx
+++ b/src/components/Escalation/Escalation.test.tsx
@@ -57,7 +57,7 @@ describe('Escalation', () => {
               id: 'p1',
               summary: 'person1',
               email: 'person1@example.com',
-              html_url: 'http://a.com/id1',
+              html_url: 'http://a.com/id1',              
             } as PagerDutyUser,
           },
         ],
@@ -75,6 +75,40 @@ describe('Escalation', () => {
     expect(getByText('person1')).toBeInTheDocument();
     expect(getByText('person1@example.com')).toBeInTheDocument();
     expect(mockPagerDutyApi.getOnCallByPolicyId).toHaveBeenCalledWith('abc');
+  });
+
+  it("Renders a user with profile picture", async () => {
+    mockPagerDutyApi.getOnCallByPolicyId = jest
+      .fn()
+      .mockImplementationOnce(async () => ({
+        oncalls: [
+          {
+            user: {
+              name: "person1",
+              id: "p1",
+              summary: "person1",
+              email: "person1@example.com",
+              html_url: "http://a.com/id1",
+              avatar_url:
+                "https://gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y",
+            } as PagerDutyUser,
+          },
+        ],
+      }));
+
+    const { getByText, queryByTestId, getByAltText } = render(
+      wrapInTestApp(
+        <ApiProvider apis={apis}>
+          <EscalationPolicy policyId="abc" />
+        </ApiProvider>
+      )
+    );
+    await waitFor(() => !queryByTestId("progress"));
+
+    expect(getByText("person1")).toBeInTheDocument();
+    expect(getByText("person1@example.com")).toBeInTheDocument();
+    expect(getByAltText("User")).toHaveAttribute("src", "https://gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y")
+    expect(mockPagerDutyApi.getOnCallByPolicyId).toHaveBeenCalledWith("abc");
   });
 
   it('Handles errors', async () => {

--- a/src/components/Escalation/EscalationPolicy.tsx
+++ b/src/components/Escalation/EscalationPolicy.tsx
@@ -39,8 +39,9 @@ export const EscalationPolicy = ({ policyId }: Props) => {
   } = useAsync(async () => {
     const { oncalls } = await api.getOnCallByPolicyId(policyId);
     const usersItem = oncalls
-      .sort((a, b) => a.escalation_level - b.escalation_level)
-      .map(oncall => oncall.user);
+      .filter((oncall) => oncall.escalation_level === 1)
+      .sort((a, b) => a.user.name > b.user.name ? 1 : -1)
+      .map((oncall) => oncall.user);
 
     return usersItem;
   });

--- a/src/components/Escalation/EscalationPolicy.tsx
+++ b/src/components/Escalation/EscalationPolicy.tsx
@@ -43,6 +43,17 @@ export const EscalationPolicy = ({ policyId }: Props) => {
       .sort((a, b) => a.user.name > b.user.name ? 1 : -1)
       .map((oncall) => oncall.user);
 
+    // remove duplicates from usersItem
+    const uniqueUsers = new Map();
+    usersItem.forEach((user) => {
+      uniqueUsers.set(user.id, user);
+    });
+
+    usersItem.length = 0;
+    uniqueUsers.forEach((user) => {
+      usersItem.push(user);
+    });
+
     return usersItem;
   });
 

--- a/src/components/Escalation/EscalationUser.tsx
+++ b/src/components/Escalation/EscalationUser.tsx
@@ -46,7 +46,7 @@ export const EscalationUser = ({ user }: Props) => {
   return (
     <ListItem>
       <ListItemIcon>
-        <Avatar alt="User" />
+        <Avatar alt="User" src={user.avatar_url} />
       </ListItemIcon>
       <ListItemText
         primary={

--- a/src/components/PagerDutyCard/index.test.tsx
+++ b/src/components/PagerDutyCard/index.test.tsx
@@ -31,6 +31,7 @@ const user: PagerDutyUser = {
   summary: 'person1',
   email: 'person1@example.com',
   html_url: 'http://a.com/id1',
+  avatar_url: 'http://a.com/id1/avatar',
 };
 
 const service: PagerDutyService = {

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -82,6 +82,7 @@ export type PagerDutyUser = {
   email: string;
   html_url: string;
   name: string;
+  avatar_url: string;
 };
 
 /** @public */


### PR DESCRIPTION
### Description

Current implementation lists all oncall users, on all escalation levels, for an escalation policy assigned to a specific service. This is how the PagerDuty API works currently.

**Problems:**
- If an escalation policy contains an oncall schedule, then the user currently on-call is returned. But if individual users are used instead all of them are listed.
- Same user might exist in different escalation levels which causes the same user to show up multiple times on the list.
- The current implementation doesn't use the gravatar image used in PagerDuty. It uses a dummy avatar icon for everyone.

**Proposed implementation:**
- List only users in escalation level 1 - these are the users that are actually oncall.
- Remove duplicate users from the oncall user list
- Add support for user profile picture and fallback to dummy avatar icon when an image is not provided.

**Issue number:** #36 

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
