### PR TITLE
feat: migrate api calls

### DIFF
--- a/dev/mockPagerDutyApi.ts
+++ b/dev/mockPagerDutyApi.ts
@@ -16,10 +16,9 @@
 import {
   PagerDutyApi,
   PagerDutyEntity,
-  PagerDutyIncident,
   PagerDutyTriggerAlarmRequest,
 } from '../src';
-import { PagerDutyChangeEvent, PagerDutyUser } from '@pagerduty/backstage-plugin-common';
+import { PagerDutyChangeEvent, PagerDutyIncident, PagerDutyUser } from '@pagerduty/backstage-plugin-common';
 import { Entity } from '@backstage/catalog-model';
 
 export const mockPagerDutyApi: PagerDutyApi = {
@@ -69,12 +68,17 @@ export const mockPagerDutyApi: PagerDutyApi = {
             },
           },
         ],
-        serviceId: serviceId,
+        service: {
+          id: serviceId,
+          summary: 'service summary',
+          html_url: 'http://service',
+        },
         created_at: '2015-10-06T21:30:42Z',
       } as PagerDutyIncident;
     };
 
     return {
+
       incidents: [
         incident('Some Alerting Incident'),
         incident('Another Alerting Incident'),

--- a/dev/mockPagerDutyApi.ts
+++ b/dev/mockPagerDutyApi.ts
@@ -15,11 +15,11 @@
  */
 import {
   PagerDutyApi,
-  PagerDutyChangeEvent,
   PagerDutyEntity,
   PagerDutyIncident,
   PagerDutyTriggerAlarmRequest,
 } from '../src';
+import { PagerDutyChangeEvent, PagerDutyUser } from '@pagerduty/backstage-plugin-common';
 import { Entity } from '@backstage/catalog-model';
 
 export const mockPagerDutyApi: PagerDutyApi = {
@@ -124,23 +124,24 @@ export const mockPagerDutyApi: PagerDutyApi = {
   },
 
   async getOnCallByPolicyId() {
-    const oncall = (id: string, name: string, escalation: number) => {
+    const oncall = (id: string, name: string) => {
       return {
-        user: {
           id: id,
           name: name,
           html_url: 'http://assignee',
           summary: 'summary',
           email: 'email@email.com',
           avatar_url: 'http://avatar',
-        },
-        escalation_level: escalation,
       };
     };
 
-    return {
-      oncalls: [oncall('1', 'Jane Doe', 1), oncall('2', 'John Doe', 2), oncall('3', 'James Doe', 1)],
-    };
+    const users: PagerDutyUser[] = [
+      oncall('1', 'Jane Doe'),
+      oncall('2', 'John Doe'),
+      oncall('3', 'James Doe'),
+    ];
+
+    return users;
   },
 
   async triggerAlarm(request: PagerDutyTriggerAlarmRequest) {

--- a/dev/mockPagerDutyApi.ts
+++ b/dev/mockPagerDutyApi.ts
@@ -27,20 +27,12 @@ export const mockPagerDutyApi: PagerDutyApi = {
     return {
       service: {
         name: pagerDutyEntity.name,
-        integrationKey: 'key',
-        id: '123',
-        html_url: 'http://service',
+        id: "SERV1CE1D",
+        html_url: "www.example.com",
         escalation_policy: {
-          id: '123',
-          html_url: 'http://escalationpolicy',
-          user: {
-            id: '123',
-            summary: 'summary',
-            email: 'email@email.com',
-            html_url: 'http://user',
-            name: 'some-user',
-            avatar_url: 'http://avatar',
-          },
+          id: "ESCALAT1ONP01ICY1D",
+          name: "ep-one",
+          html_url: "http://www.example.com/escalation-policy/ESCALAT1ONP01ICY1D",
         },
       },
     };
@@ -50,20 +42,12 @@ export const mockPagerDutyApi: PagerDutyApi = {
     return {
       service: {
         name: entity.metadata.name,
-        integrationKey: 'key',
-        id: '123',
-        html_url: 'http://service',
+        id: "SERV1CE1D",
+        html_url: "www.example.com",
         escalation_policy: {
-          id: '123',
-          html_url: 'http://escalationpolicy',
-          user: {
-            id: '123',
-            summary: 'summary',
-            email: 'email@email.com',
-            html_url: 'http://user',
-            name: 'some-user',
-            avatar_url: 'http://avatar',
-          },
+          id: "ESCALAT1ONP01ICY1D",
+          name: "ep-one",
+          html_url: "http://www.example.com/escalation-policy/ESCALAT1ONP01ICY1D",
         },
       },
     };

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",
-    "@pagerduty/backstage-plugin-common": "^0.0.1-next.7",
+    "@pagerduty/backstage-plugin-common": "^0.0.1-next.8",
     "classnames": "^2.2.6",
     "luxon": "^3.4.1",
     "react-use": "^17.2.4"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",
-    "@pagerduty/backstage-plugin-common": "^0.0.1-next.10",
     "classnames": "^2.2.6",
     "luxon": "^3.4.1",
     "react-use": "^17.2.4"
@@ -51,7 +50,8 @@
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
-    "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
+    "react-router-dom": "6.0.0-beta.0 || ^6.3.0",
+    "@pagerduty/backstage-plugin-common": "^0.0.1-next.11"
   },
   "devDependencies": {
     "@backstage/cli": "^0.24.0",
@@ -72,7 +72,8 @@
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0",
-    "typescript": "^4.8.4"
+    "typescript": "^4.8.4",
+    "@pagerduty/backstage-plugin-common": "^0.0.1-next.11"
   },
   "files": [
     "dist/**/*",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",
+    "@pagerduty/backstage-plugin-common": "^0.0.1-next.7",
     "classnames": "^2.2.6",
     "luxon": "^3.4.1",
     "react-use": "^17.2.4"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",
+    "@pagerduty/backstage-plugin-common": "^0.0.1-next.12",
     "classnames": "^2.2.6",
     "luxon": "^3.4.1",
     "react-use": "^17.2.4"
@@ -50,8 +51,7 @@
   "peerDependencies": {
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
-    "react-router-dom": "6.0.0-beta.0 || ^6.3.0",
-    "@pagerduty/backstage-plugin-common": "^0.0.1-next.11"
+    "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.24.0",
@@ -72,8 +72,7 @@
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0",
-    "typescript": "^4.8.4",
-    "@pagerduty/backstage-plugin-common": "^0.0.1-next.11"
+    "typescript": "^4.8.4"
   },
   "files": [
     "dist/**/*",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",
-    "@pagerduty/backstage-plugin-common": "^0.0.1-next.8",
+    "@pagerduty/backstage-plugin-common": "^0.0.1-next.10",
     "classnames": "^2.2.6",
     "luxon": "^3.4.1",
     "react-use": "^17.2.4"

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",
-    "@pagerduty/backstage-plugin-common": "^0.0.1-next.12",
     "classnames": "^2.2.6",
     "luxon": "^3.4.1",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
+    "@pagerduty/backstage-plugin-common": "^0.0.1-next.13",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
@@ -60,6 +60,7 @@
     "@backstage/test-utils": "^1.4.5",
     "@commitlint/cli": "^17.7.1",
     "@commitlint/config-conventional": "^17.7.0",
+    "@pagerduty/backstage-plugin-common": "^0.0.1-next.13",
     "@testing-library/dom": "^8.0.0",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^12.1.3",

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -16,8 +16,7 @@
 import { MockFetchApi } from '@backstage/test-utils';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { PagerDutyClient, UnauthorizedError } from './client';
-import { PagerDutyService } from '../components/types';
-import { PagerDutyUser} from '@pagerduty/backstage-plugin-common';
+import { PagerDutyService } from '@pagerduty/backstage-plugin-common';
 import { NotFoundError } from '@backstage/errors';
 import { Entity } from '@backstage/catalog-model';
 
@@ -26,7 +25,7 @@ const mockDiscoveryApi: jest.Mocked<DiscoveryApi> = {
   getBaseUrl: jest
     .fn()
     .mockName('discoveryApi')
-    .mockResolvedValue('http://localhost:7007/proxy'),
+    .mockResolvedValue('http://localhost:7007/pagerduty'),
 };
 const mockFetchApi: MockFetchApi = new MockFetchApi({
   baseImplementation: mockFetch,
@@ -35,25 +34,15 @@ const mockFetchApi: MockFetchApi = new MockFetchApi({
 let client: PagerDutyClient;
 let entity: Entity;
 
-const user: PagerDutyUser = {
-  name: 'person1',
-  id: 'p1',
-  summary: 'person1',
-  email: 'person1@example.com',
-  html_url: 'http://a.com/id1',
-  avatar_url: 'http://a.com/id1/avatar',
-};
-
 const service: PagerDutyService = {
-  id: 'def456',
-  name: 'pagerduty-name',
-  html_url: 'www.example.com',
+  id: "SERV1CE1D",
+  name: "service-one",
+  html_url: "www.example.com",
   escalation_policy: {
-    id: 'def',
-    user: user,
-    html_url: 'http://a.com/id1',
+    id: "ESCALAT1ONP01ICY1D",
+    name: "ep-one",
+    html_url: "http://www.example.com/escalation-policy/ESCALAT1ONP01ICY1D",
   },
-  integrationKey: 'abc123',
 };
 
 const requestHeaders = {
@@ -94,14 +83,14 @@ describe('PagerDutyClient', () => {
         mockFetch.mockResolvedValueOnce({
           status: 200,
           ok: true,
-          json: () => Promise.resolve({ services: [service] }),
+          json: () => Promise.resolve({ service }),
         });
 
         expect(await client.getServiceByEntity(entity)).toEqual({
           service,
         });
         expect(mockFetch).toHaveBeenCalledWith(
-          'http://localhost:7007/proxy/pagerduty/services?time_zone=UTC&include[]=integrations&include[]=escalation_policies&query=abc123',
+          'http://localhost:7007/pagerduty/services?integration_key=abc123',
           requestHeaders,
         );
       });
@@ -162,7 +151,7 @@ describe('PagerDutyClient', () => {
           mockFetch.mockResolvedValueOnce({
             status: 200,
             ok: true,
-            json: () => Promise.resolve({ services: [] }),
+            json: () => Promise.resolve({ }),
           });
         });
 
@@ -182,7 +171,7 @@ describe('PagerDutyClient', () => {
           metadata: {
             name: 'pagerduty-test',
             annotations: {
-              'pagerduty.com/service-id': 'def456',
+              'pagerduty.com/service-id': 'SERVICE1D',
             },
           },
         };
@@ -199,7 +188,7 @@ describe('PagerDutyClient', () => {
           service,
         });
         expect(mockFetch).toHaveBeenCalledWith(
-          'http://localhost:7007/proxy/pagerduty/services/def456?time_zone=UTC&include[]=integrations&include[]=escalation_policies',
+          'http://localhost:7007/pagerduty/services/SERVICE1D',
           requestHeaders,
         );
       });
@@ -271,18 +260,18 @@ describe('PagerDutyClient', () => {
         };
       });
 
-      it('queries proxy path by integration id', async () => {
+      it('queries pagerduty path by integration id', async () => {
         mockFetch.mockResolvedValueOnce({
           status: 200,
           ok: true,
-          json: () => Promise.resolve({ services: [service] }),
+          json: () => Promise.resolve({ service }),
         });
 
         expect(await client.getServiceByEntity(entity)).toEqual({
           service,
         });
         expect(mockFetch).toHaveBeenCalledWith(
-          'http://localhost:7007/proxy/pagerduty/services?time_zone=UTC&include[]=integrations&include[]=escalation_policies&query=abc123',
+          'http://localhost:7007/pagerduty/services?integration_key=abc123',
           requestHeaders,
         );
       });
@@ -343,7 +332,7 @@ describe('PagerDutyClient', () => {
           mockFetch.mockResolvedValueOnce({
             status: 200,
             ok: true,
-            json: () => Promise.resolve({ services: [] }),
+            json: () => Promise.resolve({ }),
           });
         });
 

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -16,7 +16,8 @@
 import { MockFetchApi } from '@backstage/test-utils';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { PagerDutyClient, UnauthorizedError } from './client';
-import { PagerDutyService, PagerDutyUser } from '../components/types';
+import { PagerDutyService } from '../components/types';
+import { PagerDutyUser} from '@pagerduty/backstage-plugin-common';
 import { NotFoundError } from '@backstage/errors';
 import { Entity } from '@backstage/catalog-model';
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -17,12 +17,15 @@
 import {
   PagerDutyApi,
   PagerDutyTriggerAlarmRequest,
-  PagerDutyIncidentsResponse,
   PagerDutyClientApiDependencies,
   PagerDutyClientApiConfig,
   RequestOptions,
 } from './types';
-import { PagerDutyChangeEventsResponse, PagerDutyOnCallUsersResponse, PagerDutyUser, PagerDutyServiceResponse } from '@pagerduty/backstage-plugin-common';
+import { PagerDutyChangeEventsResponse, 
+  PagerDutyOnCallUsersResponse, 
+  PagerDutyUser, 
+  PagerDutyServiceResponse,
+  PagerDutyIncidentsResponse } from '@pagerduty/backstage-plugin-common';
 import { createApiRef, ConfigApi } from '@backstage/core-plugin-api';
 import { NotFoundError } from '@backstage/errors';
 import { Entity } from '@backstage/catalog-model';
@@ -94,10 +97,9 @@ export class PagerDutyClient implements PagerDutyApi {
   async getIncidentsByServiceId(
     serviceId: string,
   ): Promise<PagerDutyIncidentsResponse> {
-    const params = `time_zone=UTC&sort_by=created_at&statuses[]=triggered&statuses[]=acknowledged&service_ids[]=${serviceId}`;
     const url = `${await this.config.discoveryApi.getBaseUrl(
-      'proxy',
-    )}/pagerduty/incidents?${params}`;
+      'pagerduty',
+    )}/services/${serviceId}/incidents`;
 
     return await this.findByUrl<PagerDutyIncidentsResponse>(url);
   }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -24,7 +24,7 @@ import {
   PagerDutyClientApiConfig,
   RequestOptions,
 } from './types';
-import { PagerDutyChangeEventsResponse, PagerDutyUser } from '@pagerduty/backstage-plugin-common';
+import { PagerDutyChangeEventsResponse, PagerDutyOnCallUsersResponse, PagerDutyUser } from '@pagerduty/backstage-plugin-common';
 import { createApiRef, ConfigApi } from '@backstage/core-plugin-api';
 import { NotFoundError } from '@backstage/errors';
 import { Entity } from '@backstage/catalog-model';
@@ -127,7 +127,8 @@ export class PagerDutyClient implements PagerDutyApi {
       'pagerduty',
     )}/oncall-users?${params}`;
 
-    return await this.findByUrl<PagerDutyUser[]>(url);
+    const response: PagerDutyOnCallUsersResponse = await this.findByUrl<PagerDutyOnCallUsersResponse>(url);
+    return response.users;
   }
 
   triggerAlarm(request: PagerDutyTriggerAlarmRequest): Promise<Response> {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -37,9 +37,6 @@ export const pagerDutyApiRef = createApiRef<PagerDutyApi>({
   id: 'plugin.pagerduty.api',
 });
 
-const commonGetServiceParams =
-  'time_zone=UTC&include[]=integrations&include[]=escalation_policies';
-
 /** @public */
 export class PagerDutyClient implements PagerDutyApi {
   static fromConfig(
@@ -108,10 +105,9 @@ export class PagerDutyClient implements PagerDutyApi {
   async getChangeEventsByServiceId(
     serviceId: string,
   ): Promise<PagerDutyChangeEventsResponse> {
-    const params = `limit=5&time_zone=UTC&sort_by=timestamp`;
     const url = `${await this.config.discoveryApi.getBaseUrl(
-      'proxy',
-    )}/pagerduty/services/${serviceId}/change_events?${params}`;
+      'pagerduty',
+    )}/services/${serviceId}/change-events`;
 
     return await this.findByUrl<PagerDutyChangeEventsResponse>(url);
   }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -20,12 +20,11 @@ import {
   PagerDutyServicesResponse,
   PagerDutyServiceResponse,
   PagerDutyIncidentsResponse,
-  PagerDutyOnCallsResponse,
   PagerDutyClientApiDependencies,
   PagerDutyClientApiConfig,
   RequestOptions,
-  PagerDutyChangeEventsResponse,
 } from './types';
+import { PagerDutyChangeEventsResponse, PagerDutyUser } from '@pagerduty/backstage-plugin-common';
 import { createApiRef, ConfigApi } from '@backstage/core-plugin-api';
 import { NotFoundError } from '@backstage/errors';
 import { Entity } from '@backstage/catalog-model';
@@ -122,13 +121,13 @@ export class PagerDutyClient implements PagerDutyApi {
 
   async getOnCallByPolicyId(
     policyId: string,
-  ): Promise<PagerDutyOnCallsResponse> {
-    const params = `time_zone=UTC&include[]=users&escalation_policy_ids[]=${policyId}`;
+  ): Promise<PagerDutyUser[]> {
+    const params = `escalation_policy_ids[]=${policyId}`;
     const url = `${await this.config.discoveryApi.getBaseUrl(
-      'proxy',
-    )}/pagerduty/oncalls?${params}`;
+      'pagerduty',
+    )}/oncall-users?${params}`;
 
-    return await this.findByUrl<PagerDutyOnCallsResponse>(url);
+    return await this.findByUrl<PagerDutyUser[]>(url);
   }
 
   triggerAlarm(request: PagerDutyTriggerAlarmRequest): Promise<Response> {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -25,7 +25,8 @@ import { PagerDutyChangeEventsResponse,
   PagerDutyOnCallUsersResponse, 
   PagerDutyUser, 
   PagerDutyServiceResponse,
-  PagerDutyIncidentsResponse } from '@pagerduty/backstage-plugin-common';
+  PagerDutyIncidentsResponse 
+} from '@pagerduty/backstage-plugin-common';
 import { createApiRef, ConfigApi } from '@backstage/core-plugin-api';
 import { NotFoundError } from '@backstage/errors';
 import { Entity } from '@backstage/catalog-model';

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -17,14 +17,12 @@
 import {
   PagerDutyApi,
   PagerDutyTriggerAlarmRequest,
-  PagerDutyServicesResponse,
-  PagerDutyServiceResponse,
   PagerDutyIncidentsResponse,
   PagerDutyClientApiDependencies,
   PagerDutyClientApiConfig,
   RequestOptions,
 } from './types';
-import { PagerDutyChangeEventsResponse, PagerDutyOnCallUsersResponse, PagerDutyUser } from '@pagerduty/backstage-plugin-common';
+import { PagerDutyChangeEventsResponse, PagerDutyOnCallUsersResponse, PagerDutyUser, PagerDutyServiceResponse } from '@pagerduty/backstage-plugin-common';
 import { createApiRef, ConfigApi } from '@backstage/core-plugin-api';
 import { NotFoundError } from '@backstage/errors';
 import { Entity } from '@backstage/catalog-model';
@@ -73,18 +71,17 @@ export class PagerDutyClient implements PagerDutyApi {
 
     if (integrationKey) {
       url = `${await this.config.discoveryApi.getBaseUrl(
-        'proxy',
-      )}/pagerduty/services?${commonGetServiceParams}&query=${integrationKey}`;
-      const { services } = await this.findByUrl<PagerDutyServicesResponse>(url);
-      const service = services[0];
+        'pagerduty',
+      )}/services?integration_key=${integrationKey}`;
+      const serviceResponse = await this.findByUrl<PagerDutyServiceResponse>(url);
 
-      if (!service) throw new NotFoundError();
+      if (serviceResponse.service === undefined) throw new NotFoundError();
 
-      response = { service };
+      response = serviceResponse;
     } else if (serviceId) {
       url = `${await this.config.discoveryApi.getBaseUrl(
-        'proxy',
-      )}/pagerduty/services/${serviceId}?${commonGetServiceParams}`;
+        'pagerduty',
+      )}/services/${serviceId}`;
 
       response = await this.findByUrl<PagerDutyServiceResponse>(url);
     } else {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -17,7 +17,6 @@
 export { PagerDutyClient, pagerDutyApiRef, UnauthorizedError } from './client';
 export type {
   PagerDutyApi,
-  PagerDutyIncidentsResponse,
   PagerDutyTriggerAlarmRequest,
   PagerDutyClientApiDependencies,
   PagerDutyClientApiConfig,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -19,8 +19,6 @@ export type {
   PagerDutyApi,
   PagerDutyServiceResponse,
   PagerDutyIncidentsResponse,
-  PagerDutyChangeEventsResponse,
-  PagerDutyOnCallsResponse,
   PagerDutyTriggerAlarmRequest,
   PagerDutyClientApiDependencies,
   PagerDutyClientApiConfig,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -17,7 +17,6 @@
 export { PagerDutyClient, pagerDutyApiRef, UnauthorizedError } from './client';
 export type {
   PagerDutyApi,
-  PagerDutyServiceResponse,
   PagerDutyIncidentsResponse,
   PagerDutyTriggerAlarmRequest,
   PagerDutyClientApiDependencies,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -16,21 +16,11 @@
 
 import {
   PagerDutyIncident,
-  PagerDutyService,
 } from '../components/types';
-import { PagerDutyChangeEventsResponse, PagerDutyUser } from '@pagerduty/backstage-plugin-common';
+import { PagerDutyChangeEventsResponse, PagerDutyServiceResponse, PagerDutyUser } from '@pagerduty/backstage-plugin-common';
 import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { PagerDutyEntity } from '../types';
-
-export type PagerDutyServicesResponse = {
-  services: PagerDutyService[];
-};
-
-/** @public */
-export type PagerDutyServiceResponse = {
-  service: PagerDutyService;
-};
 
 /** @public */
 export type PagerDutyIncidentsResponse = {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -16,10 +16,9 @@
 
 import {
   PagerDutyIncident,
-  PagerDutyChangeEvent,
-  PagerDutyOnCall,
   PagerDutyService,
 } from '../components/types';
+import { PagerDutyChangeEventsResponse, PagerDutyUser } from '@pagerduty/backstage-plugin-common';
 import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { PagerDutyEntity } from '../types';
@@ -38,15 +37,6 @@ export type PagerDutyIncidentsResponse = {
   incidents: PagerDutyIncident[];
 };
 
-/** @public */
-export type PagerDutyChangeEventsResponse = {
-  change_events: PagerDutyChangeEvent[];
-};
-
-/** @public */
-export type PagerDutyOnCallsResponse = {
-  oncalls: PagerDutyOnCall[];
-};
 
 /** @public */
 export type PagerDutyTriggerAlarmRequest = {
@@ -92,7 +82,7 @@ export interface PagerDutyApi {
    * Fetches the list of users in an escalation policy.
    *
    */
-  getOnCallByPolicyId(policyId: string): Promise<PagerDutyOnCallsResponse>;
+  getOnCallByPolicyId(policyId: string): Promise<PagerDutyUser[]>;
 
   /**
    * Triggers an incident to whoever is on-call.

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -14,19 +14,10 @@
  * limitations under the License.
  */
 
-import {
-  PagerDutyIncident,
-} from '../components/types';
-import { PagerDutyChangeEventsResponse, PagerDutyServiceResponse, PagerDutyUser } from '@pagerduty/backstage-plugin-common';
+import { PagerDutyChangeEventsResponse, PagerDutyServiceResponse, PagerDutyUser, PagerDutyIncidentsResponse } from '@pagerduty/backstage-plugin-common';
 import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { PagerDutyEntity } from '../types';
-
-/** @public */
-export type PagerDutyIncidentsResponse = {
-  incidents: PagerDutyIncident[];
-};
-
 
 /** @public */
 export type PagerDutyTriggerAlarmRequest = {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { PagerDutyChangeEventsResponse, PagerDutyServiceResponse, PagerDutyUser, PagerDutyIncidentsResponse } from '@pagerduty/backstage-plugin-common';
+import { PagerDutyChangeEventsResponse, 
+  PagerDutyServiceResponse, 
+  PagerDutyUser, 
+  PagerDutyIncidentsResponse
+ } from '@pagerduty/backstage-plugin-common';
 import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { PagerDutyEntity } from '../types';

--- a/src/components/ChangeEvents/ChangeEventListItem.tsx
+++ b/src/components/ChangeEvents/ChangeEventListItem.tsx
@@ -27,7 +27,7 @@ import {
   Typography,
 } from '@material-ui/core';
 import { DateTime, Duration } from 'luxon';
-import { PagerDutyChangeEvent } from '../types';
+import { PagerDutyChangeEvent } from '@pagerduty/backstage-plugin-common';
 import OpenInBrowserIcon from '@material-ui/icons/OpenInBrowser';
 import { BackstageTheme } from '@backstage/theme';
 

--- a/src/components/ChangeEvents/ChangeEvents.test.tsx
+++ b/src/components/ChangeEvents/ChangeEvents.test.tsx
@@ -16,7 +16,7 @@
 // eslint-disable-next-line @backstage/no-undeclared-imports
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
-import { PagerDutyChangeEvent } from '../types';
+import { PagerDutyChangeEvent } from '@pagerduty/backstage-plugin-common';
 import { TestApiRegistry, wrapInTestApp } from '@backstage/test-utils';
 import { pagerDutyApiRef } from '../../api';
 import { ApiProvider } from '@backstage/core-app-api';

--- a/src/components/EntityPagerDutyCard/index.test.tsx
+++ b/src/components/EntityPagerDutyCard/index.test.tsx
@@ -25,8 +25,7 @@ import { EntityProvider } from '@backstage/plugin-catalog-react';
 import { NotFoundError } from '@backstage/errors';
 import { TestApiRegistry, wrapInTestApp } from '@backstage/test-utils';
 import { pagerDutyApiRef, UnauthorizedError, PagerDutyClient } from '../../api';
-import { PagerDutyService } from '../types';
-import { PagerDutyUser } from '@pagerduty/backstage-plugin-common';
+import { PagerDutyUser, PagerDutyService } from '@pagerduty/backstage-plugin-common';
 
 import { alertApiRef } from '@backstage/core-plugin-api';
 import { ApiProvider } from '@backstage/core-app-api';
@@ -74,25 +73,15 @@ const entityWithAllAnnotations: Entity = {
   },
 };
 
-const user: PagerDutyUser = {
-  name: 'person1',
-  id: 'p1',
-  summary: 'person1',
-  email: 'person1@example.com',
-  html_url: 'http://a.com/id1',
-  avatar_url: 'http://a.com/id1/avatar',
-};
-
 const service: PagerDutyService = {
-  id: 'def456',
-  name: 'pagerduty-name',
-  html_url: 'www.example.com',
+  id: "SERV1CE1D",
+  name: "service-one",
+  html_url: "www.example.com",
   escalation_policy: {
-    id: 'def',
-    user: user,
-    html_url: 'http://a.com/id1',
+    id: "ESCALAT1ONP01ICY1D",
+    name: "ep-one",
+    html_url: "http://www.example.com/escalation-policy/ESCALAT1ONP01ICY1D",
   },
-  integrationKey: 'abc123',
 };
 
 const oncallUsers: PagerDutyUser[] = []

--- a/src/components/EntityPagerDutyCard/index.test.tsx
+++ b/src/components/EntityPagerDutyCard/index.test.tsx
@@ -25,7 +25,8 @@ import { EntityProvider } from '@backstage/plugin-catalog-react';
 import { NotFoundError } from '@backstage/errors';
 import { TestApiRegistry, wrapInTestApp } from '@backstage/test-utils';
 import { pagerDutyApiRef, UnauthorizedError, PagerDutyClient } from '../../api';
-import { PagerDutyService, PagerDutyUser } from '../types';
+import { PagerDutyService } from '../types';
+import { PagerDutyUser } from '@pagerduty/backstage-plugin-common';
 
 import { alertApiRef } from '@backstage/core-plugin-api';
 import { ApiProvider } from '@backstage/core-app-api';
@@ -94,10 +95,12 @@ const service: PagerDutyService = {
   integrationKey: 'abc123',
 };
 
+const oncallUsers: PagerDutyUser[] = []
+
 const mockPagerDutyApi: Partial<PagerDutyClient> = {
   getServiceByEntity: async () => ({ service }),
   getServiceByPagerDutyEntity: async () => ({ service }),
-  getOnCallByPolicyId: async () => ({ oncalls: [] }),
+  getOnCallByPolicyId: async () => ( oncallUsers),
   getIncidentsByServiceId: async () => ({ incidents: [] }),
 };
 
@@ -151,7 +154,7 @@ describe('EntityPagerDutyCard', () => {
     expect(getByText('Service Directory')).toBeInTheDocument();
     expect(getByText('Create Incident')).toBeInTheDocument();
     expect(getByText('Nice! No incidents found!')).toBeInTheDocument();
-    expect(getByText('Empty escalation policy')).toBeInTheDocument();
+    expect(getByText('No one is on-call. Update the escalation policy.')).toBeInTheDocument();
   });
 
   it('Handles custom error for missing token', async () => {
@@ -255,7 +258,7 @@ describe('EntityPagerDutyCard', () => {
       expect(getByText('Service Directory')).toBeInTheDocument();
       expect(getByText('Create Incident')).toBeInTheDocument();
       expect(getByText('Nice! No incidents found!')).toBeInTheDocument();
-      expect(getByText('Empty escalation policy')).toBeInTheDocument();
+      expect(getByText('No one is on-call. Update the escalation policy.')).toBeInTheDocument();
     });
 
     it('Handles custom error for missing token', async () => {
@@ -359,7 +362,7 @@ describe('EntityPagerDutyCard', () => {
       expect(getByText('Service Directory')).toBeInTheDocument();
       expect(getByText('Create Incident')).toBeInTheDocument();
       expect(getByText('Nice! No incidents found!')).toBeInTheDocument();
-      expect(getByText('Empty escalation policy')).toBeInTheDocument();
+      expect(getByText('No one is on-call. Update the escalation policy.')).toBeInTheDocument();
     });
   });
 
@@ -381,7 +384,7 @@ describe('EntityPagerDutyCard', () => {
       await waitFor(() => !queryByTestId('progress'));
       expect(getByText('Service Directory')).toBeInTheDocument();
       expect(getByText('Nice! No incidents found!')).toBeInTheDocument();
-      expect(getByText('Empty escalation policy')).toBeInTheDocument();
+      expect(getByText('No one is on-call. Update the escalation policy.')).toBeInTheDocument();
       expect(() => getByText('Create Incident')).toThrow();
     });
   });

--- a/src/components/Escalation/Escalation.test.tsx
+++ b/src/components/Escalation/Escalation.test.tsx
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 // eslint-disable-next-line @backstage/no-undeclared-imports
-import React from 'react';
-import { render, waitFor } from '@testing-library/react';
-import { EscalationPolicy } from './EscalationPolicy';
-import { TestApiRegistry, wrapInTestApp } from '@backstage/test-utils';
-import { PagerDutyUser } from '../types';
-import { pagerDutyApiRef } from '../../api';
-import { ApiProvider } from '@backstage/core-app-api';
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { EscalationPolicy } from "./EscalationPolicy";
+import { TestApiRegistry, wrapInTestApp } from "@backstage/test-utils";
+import { PagerDutyUser } from "@pagerduty/backstage-plugin-common";
+import { pagerDutyApiRef } from "../../api";
+import { ApiProvider } from "@backstage/core-app-api";
 
 const mockPagerDutyApi = {
   getOnCallByPolicyId: jest.fn(),
 };
 const apis = TestApiRegistry.from([pagerDutyApiRef, mockPagerDutyApi]);
 
-describe('Escalation', () => {
-  it('Handles an empty response', async () => {
+describe("Escalation", () => {
+  it("Handles an empty response", async () => {
     mockPagerDutyApi.getOnCallByPolicyId = jest
       .fn()
       .mockImplementationOnce(async () => ({ oncalls: [] }));
@@ -37,89 +37,34 @@ describe('Escalation', () => {
       wrapInTestApp(
         <ApiProvider apis={apis}>
           <EscalationPolicy policyId="456" />
-        </ApiProvider>,
-      ),
+        </ApiProvider>
+      )
     );
-    await waitFor(() => !queryByTestId('progress'));
+    await waitFor(() => !queryByTestId("progress"));
 
-    expect(getByText('Empty escalation policy')).toBeInTheDocument();
-    expect(mockPagerDutyApi.getOnCallByPolicyId).toHaveBeenCalledWith('456');
+    expect(getByText("No one is on-call. Update the escalation policy.")).toBeInTheDocument();
+    expect(mockPagerDutyApi.getOnCallByPolicyId).toHaveBeenCalledWith("456");
   });
 
-  it('Render a list of users', async () => {
+  it("Render a list of users", async () => {
     mockPagerDutyApi.getOnCallByPolicyId = jest
       .fn()
-      .mockImplementationOnce(async () => ({
-        oncalls: [
+      .mockImplementationOnce(async () => (
+        [
           {
-            user: {
-              name: 'person1',
-              id: 'p1',
-              summary: 'person1',
-              email: 'person1@example.com',
-              html_url: 'http://a.com/id1',              
-            } as PagerDutyUser,
-            escalation_level: 1,
+              name: "person1",
+              id: "p1",
+              summary: "person1",
+              email: "person1@example.com",
+              html_url: "http://a.com/id1",
           },
-        ],
-      }));
+        ] as PagerDutyUser[]
+      ));
 
     const { getByText, queryByTestId } = render(
       wrapInTestApp(
         <ApiProvider apis={apis}>
           <EscalationPolicy policyId="abc" />
-        </ApiProvider>,
-      ),
-    );
-    await waitFor(() => !queryByTestId('progress'));
-
-    expect(getByText('person1')).toBeInTheDocument();
-    expect(getByText('person1@example.com')).toBeInTheDocument();
-    expect(mockPagerDutyApi.getOnCallByPolicyId).toHaveBeenCalledWith('abc');
-  });
-
-  it("Renders a list of users without duplicates", async () => {
-    mockPagerDutyApi.getOnCallByPolicyId = jest
-      .fn()
-      .mockImplementationOnce(async () => ({
-        oncalls: [
-          {
-            user: {
-              name: "person1",
-              id: "p1",
-              summary: "person1",
-              email: "person1@example.com",
-              html_url: "http://a.com/id1",
-            } as PagerDutyUser,
-            escalation_level: 1,
-          },
-          {
-            user: {
-              name: "person2",
-              id: "p2",
-              summary: "person2",
-              email: "person2@example.com",
-              html_url: "http://a.com/id2",
-            } as PagerDutyUser,
-            escalation_level: 1,
-          },
-          {
-            user: {
-              name: "person2",
-              id: "p2",
-              summary: "person2",
-              email: "person2@example.com",
-              html_url: "http://a.com/id2",
-            } as PagerDutyUser,
-            escalation_level: 1,
-          },
-        ],
-      }));
-
-    const { getByText, queryByTestId, queryAllByText } = render(
-      wrapInTestApp(
-        <ApiProvider apis={apis}>
-          <EscalationPolicy policyId="abc" />
         </ApiProvider>
       )
     );
@@ -127,74 +72,25 @@ describe('Escalation', () => {
 
     expect(getByText("person1")).toBeInTheDocument();
     expect(getByText("person1@example.com")).toBeInTheDocument();
-    expect(queryAllByText("person2").length).toBe(1);
-    expect(queryAllByText("person2@example.com").length).toBe(1);
-    expect(mockPagerDutyApi.getOnCallByPolicyId).toHaveBeenCalledWith("abc");
-  });
-
-  it("Renders only user(s) in escalation level 1", async () => {
-    mockPagerDutyApi.getOnCallByPolicyId = jest
-      .fn()
-      .mockImplementationOnce(async () => ({
-        oncalls: [
-          {
-            user: {
-              name: "person1",
-              id: "p1",
-              summary: "person1",
-              email: "person1@example.com",
-              html_url: "http://a.com/id1",
-            } as PagerDutyUser,
-            escalation_level: 1,
-          },
-          {
-            user: {
-              name: "person2",
-              id: "p2",
-              summary: "person2",
-              email: "person2@example.com",
-              html_url: "http://a.com/id2",
-            } as PagerDutyUser,
-            escalation_level: 2,
-          },
-        ],
-      }));
-
-    const { getByText, queryByTestId, queryByText } = render(
-      wrapInTestApp(
-        <ApiProvider apis={apis}>
-          <EscalationPolicy policyId="abc" />
-        </ApiProvider>
-      )
-    );
-    await waitFor(() => !queryByTestId("progress"));
-
-    expect(getByText("person1")).toBeInTheDocument();
-    expect(getByText("person1@example.com")).toBeInTheDocument();
-    expect(queryByText("person2")).not.toBeInTheDocument();
-    expect(queryByText("person2@example.com")).not.toBeInTheDocument();
     expect(mockPagerDutyApi.getOnCallByPolicyId).toHaveBeenCalledWith("abc");
   });
 
   it("Renders a user with profile picture", async () => {
     mockPagerDutyApi.getOnCallByPolicyId = jest
       .fn()
-      .mockImplementationOnce(async () => ({
-        oncalls: [
+      .mockImplementationOnce(async () => (
+        [
           {
-            user: {
-              name: "person1",
-              id: "p1",
-              summary: "person1",
-              email: "person1@example.com",
-              html_url: "http://a.com/id1",
-              avatar_url:
-                "https://gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y",
-            } as PagerDutyUser,
-            escalation_level: 1,
+            name: "person1",
+            id: "p1",
+            summary: "person1",
+            email: "person1@example.com",
+            html_url: "http://a.com/id1",
+            avatar_url:
+              "https://gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y",
           },
-        ],
-      }));
+        ] as PagerDutyUser[]
+      ));
 
     const { getByText, queryByTestId, getByAltText } = render(
       wrapInTestApp(
@@ -207,26 +103,29 @@ describe('Escalation', () => {
 
     expect(getByText("person1")).toBeInTheDocument();
     expect(getByText("person1@example.com")).toBeInTheDocument();
-    expect(getByAltText("User")).toHaveAttribute("src", "https://gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y")
+    expect(getByAltText("User")).toHaveAttribute(
+      "src",
+      "https://gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?f=y"
+    );
     expect(mockPagerDutyApi.getOnCallByPolicyId).toHaveBeenCalledWith("abc");
   });
 
-  it('Handles errors', async () => {
+  it("Handles errors", async () => {
     mockPagerDutyApi.getOnCallByPolicyId = jest
       .fn()
-      .mockRejectedValueOnce(new Error('Error message'));
+      .mockRejectedValueOnce(new Error("Error message"));
 
     const { getByText, queryByTestId } = render(
       wrapInTestApp(
         <ApiProvider apis={apis}>
           <EscalationPolicy policyId="abc" />
-        </ApiProvider>,
-      ),
+        </ApiProvider>
+      )
     );
-    await waitFor(() => !queryByTestId('progress'));
+    await waitFor(() => !queryByTestId("progress"));
 
     expect(
-      getByText('Error encountered while fetching information. Error message'),
+      getByText("Error encountered while fetching information. Error message")
     ).toBeInTheDocument();
   });
 });

--- a/src/components/Escalation/EscalationPolicy.tsx
+++ b/src/components/Escalation/EscalationPolicy.tsx
@@ -37,24 +37,7 @@ export const EscalationPolicy = ({ policyId }: Props) => {
     loading,
     error,
   } = useAsync(async () => {
-    const { oncalls } = await api.getOnCallByPolicyId(policyId);
-    const usersItem = oncalls
-      .filter((oncall) => oncall.escalation_level === 1)
-      .sort((a, b) => a.user.name > b.user.name ? 1 : -1)
-      .map((oncall) => oncall.user);
-
-    // remove duplicates from usersItem
-    const uniqueUsers = new Map();
-    usersItem.forEach((user) => {
-      uniqueUsers.set(user.id, user);
-    });
-
-    usersItem.length = 0;
-    uniqueUsers.forEach((user) => {
-      usersItem.push(user);
-    });
-
-    return usersItem;
+    return await api.getOnCallByPolicyId(policyId);
   });
 
   if (error) {

--- a/src/components/Escalation/EscalationUser.tsx
+++ b/src/components/Escalation/EscalationUser.tsx
@@ -28,7 +28,7 @@ import {
 import Avatar from '@material-ui/core/Avatar';
 import EmailIcon from '@material-ui/icons/Email';
 import OpenInBrowserIcon from '@material-ui/icons/OpenInBrowser';
-import { PagerDutyUser } from '../types';
+import { PagerDutyUser } from '@pagerduty/backstage-plugin-common';
 
 const useStyles = makeStyles({
   listItemPrimary: {

--- a/src/components/Escalation/EscalationUsersEmptyState.tsx
+++ b/src/components/Escalation/EscalationUsersEmptyState.tsx
@@ -42,7 +42,7 @@ export const EscalationUsersEmptyState = () => {
           <StatusWarning />
         </div>
       </ListItemIcon>
-      <ListItemText primary="Empty escalation policy" />
+      <ListItemText primary="No one is on-call. Update the escalation policy." />
     </ListItem>
   );
 };

--- a/src/components/Incident/IncidentListItem.tsx
+++ b/src/components/Incident/IncidentListItem.tsx
@@ -28,7 +28,7 @@ import {
 import Done from '@material-ui/icons/Done';
 import Warning from '@material-ui/icons/Warning';
 import { DateTime, Duration } from 'luxon';
-import { PagerDutyIncident } from '../types';
+import { PagerDutyIncident } from '@pagerduty/backstage-plugin-common';
 import OpenInBrowserIcon from '@material-ui/icons/OpenInBrowser';
 import { BackstageTheme } from '@backstage/theme';
 import { Link } from '@backstage/core-components';

--- a/src/components/Incident/Incidents.test.tsx
+++ b/src/components/Incident/Incidents.test.tsx
@@ -19,7 +19,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { Incidents } from './Incidents';
 import { TestApiRegistry, wrapInTestApp } from '@backstage/test-utils';
 import { pagerDutyApiRef } from '../../api';
-import { PagerDutyIncident } from '../types';
+import { PagerDutyIncident } from '@pagerduty/backstage-plugin-common';
 import { ApiProvider } from '@backstage/core-app-api';
 
 const mockPagerDutyApi = {
@@ -64,7 +64,16 @@ describe('Incidents', () => {
               },
             ],
             html_url: 'http://a.com/id1',
-            serviceId: 'sId1',
+            service: {
+              id: 'sId1',
+              name: 'sName1',
+              html_url: 'http://a.com/sId1',
+              escalation_policy: {
+                id: 'ep1',
+                summary: 'ep1',
+                html_url: 'http://a.com/ep1',
+              },
+            }
           },
           {
             id: 'id2',

--- a/src/components/PagerDutyCard/index.test.tsx
+++ b/src/components/PagerDutyCard/index.test.tsx
@@ -20,35 +20,24 @@ import { PagerDutyCard } from '../PagerDutyCard';
 import { NotFoundError } from '@backstage/errors';
 import { TestApiRegistry, wrapInTestApp } from '@backstage/test-utils';
 import { pagerDutyApiRef, UnauthorizedError, PagerDutyClient } from '../../api';
-import { PagerDutyService } from '../types';
-import { PagerDutyUser } from '@pagerduty/backstage-plugin-common';
+import { PagerDutyService } from '@pagerduty/backstage-plugin-common';
 
 import { alertApiRef } from '@backstage/core-plugin-api';
 import { ApiProvider } from '@backstage/core-app-api';
 
-const user: PagerDutyUser = {
-  name: 'person1',
-  id: 'p1',
-  summary: 'person1',
-  email: 'person1@example.com',
-  html_url: 'http://a.com/id1',
-  avatar_url: 'http://a.com/id1/avatar',
-};
-
 const service: PagerDutyService = {
-  id: 'def456',
-  name: 'pagerduty-name',
-  html_url: 'www.example.com',
+  id: "SERV1CE1D",
+  name: "service-one",
+  html_url: "www.example.com",
   escalation_policy: {
-    id: 'def',
-    user: user,
-    html_url: 'http://a.com/id1',
+    id: "ESCALAT1ONP01ICY1D",
+    name: "ep-one",
+    html_url: "http://www.example.com/escalation-policy/ESCALAT1ONP01ICY1D",
   },
-  integrationKey: 'abc123',
 };
 
 const mockPagerDutyApi: Partial<PagerDutyClient> = {
-  getServiceByEntity: async () => ({ service }),
+  getServiceByEntity: async () => ( { service }),
   getOnCallByPolicyId: async () => ([]),
   getIncidentsByServiceId: async () => ({ incidents: [] }),
 };

--- a/src/components/PagerDutyCard/index.test.tsx
+++ b/src/components/PagerDutyCard/index.test.tsx
@@ -20,7 +20,8 @@ import { PagerDutyCard } from '../PagerDutyCard';
 import { NotFoundError } from '@backstage/errors';
 import { TestApiRegistry, wrapInTestApp } from '@backstage/test-utils';
 import { pagerDutyApiRef, UnauthorizedError, PagerDutyClient } from '../../api';
-import { PagerDutyService, PagerDutyUser } from '../types';
+import { PagerDutyService } from '../types';
+import { PagerDutyUser } from '@pagerduty/backstage-plugin-common';
 
 import { alertApiRef } from '@backstage/core-plugin-api';
 import { ApiProvider } from '@backstage/core-app-api';
@@ -48,7 +49,7 @@ const service: PagerDutyService = {
 
 const mockPagerDutyApi: Partial<PagerDutyClient> = {
   getServiceByEntity: async () => ({ service }),
-  getOnCallByPolicyId: async () => ({ oncalls: [] }),
+  getOnCallByPolicyId: async () => ([]),
   getIncidentsByServiceId: async () => ({ incidents: [] }),
 };
 
@@ -74,7 +75,7 @@ describe('PagerDutyCard', () => {
     expect(getByText('Service Directory')).toBeInTheDocument();
     expect(getByText('Create Incident')).toBeInTheDocument();
     expect(getByText('Nice! No incidents found!')).toBeInTheDocument();
-    expect(getByText('Empty escalation policy')).toBeInTheDocument();
+    expect(getByText('No one is on-call. Update the escalation policy.')).toBeInTheDocument();
   });
 
   it('Handles custom error for missing token', async () => {
@@ -168,7 +169,7 @@ describe('PagerDutyCard', () => {
       expect(getByText('Service Directory')).toBeInTheDocument();
       expect(getByText('Create Incident')).toBeInTheDocument();
       expect(getByText('Nice! No incidents found!')).toBeInTheDocument();
-      expect(getByText('Empty escalation policy')).toBeInTheDocument();
+      expect(getByText('No one is on-call. Update the escalation policy.')).toBeInTheDocument();
     });
 
     it('Handles custom error for missing token', async () => {
@@ -278,7 +279,7 @@ describe('PagerDutyCard', () => {
       expect(getByText('Service Directory')).toBeInTheDocument();
       expect(getByText('Create Incident')).toBeInTheDocument();
       expect(getByText('Nice! No incidents found!')).toBeInTheDocument();
-      expect(getByText('Empty escalation policy')).toBeInTheDocument();
+      expect(getByText('No one is on-call. Update the escalation policy.')).toBeInTheDocument();
     });
   });
 
@@ -303,7 +304,7 @@ describe('PagerDutyCard', () => {
       await waitFor(() => !queryByTestId('progress'));
       expect(getByText('Service Directory')).toBeInTheDocument();
       expect(getByText('Nice! No incidents found!')).toBeInTheDocument();
-      expect(getByText('Empty escalation policy')).toBeInTheDocument();
+      expect(getByText('No one is on-call. Update the escalation policy.')).toBeInTheDocument();
       expect(() => getByText('Create Incident')).toThrow();
     });
   });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -15,12 +15,10 @@
  */
 
 export type {
-  PagerDutyChangeEvent,
   PagerDutyIncident,
   PagerDutyService,
   PagerDutyOnCall,
   PagerDutyAssignee,
-  PagerDutyUser,
 } from './types';
 
 export type { EntityPagerDutyCardProps } from './EntityPagerDutyCard';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-export type {
-  PagerDutyIncident,
-  PagerDutyService,
-  PagerDutyOnCall,
-  PagerDutyAssignee,
-} from './types';
 
 export type { EntityPagerDutyCardProps } from './EntityPagerDutyCard';
 export type { HomePagePagerDutyCardProps } from './HomePagePagerDutyCard';

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -14,49 +14,6 @@
  * limitations under the License.
  */
 
-import { PagerDutyUser } from '@pagerduty/backstage-plugin-common';
-
-/** @public */
-export type PagerDutyIncident = {
-  id: string;
-  title: string;
-  status: string;
-  html_url: string;
-  assignments: [
-    {
-      assignee: PagerDutyAssignee;
-    },
-  ];
-  serviceId: string;
-  created_at: string;
-};
-
-/** @public */
-export type PagerDutyService = {
-  id: string;
-  name: string;
-  html_url: string;
-  integrationKey: string;
-  escalation_policy: {
-    id: string;
-    user: PagerDutyUser;
-    html_url: string;
-  };
-};
-
-/** @public */
-export type PagerDutyOnCall = {
-  user: PagerDutyUser;
-  escalation_level: number;
-};
-
-/** @public */
-export type PagerDutyAssignee = {
-  id: string;
-  summary: string;
-  html_url: string;
-};
-
 /** @public */
 export type SubHeaderLink = {
   title: string;

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -14,25 +14,7 @@
  * limitations under the License.
  */
 
-/** @public */
-export type PagerDutyChangeEvent = {
-  id: string;
-  integration: [
-    {
-      service: PagerDutyService;
-    },
-  ];
-  source: string;
-  html_url: string;
-  links: [
-    {
-      href: string;
-      text: string;
-    },
-  ];
-  summary: string;
-  timestamp: string;
-};
+import { PagerDutyUser } from '@pagerduty/backstage-plugin-common';
 
 /** @public */
 export type PagerDutyIncident = {
@@ -73,16 +55,6 @@ export type PagerDutyAssignee = {
   id: string;
   summary: string;
   html_url: string;
-};
-
-/** @public */
-export type PagerDutyUser = {
-  id: string;
-  summary: string;
-  email: string;
-  html_url: string;
-  name: string;
-  avatar_url: string;
 };
 
 /** @public */

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,10 +4242,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagerduty/backstage-plugin-common@npm:^0.0.1-next.10":
-  version: 0.0.1-next.10
-  resolution: "@pagerduty/backstage-plugin-common@npm:0.0.1-next.10"
-  checksum: 94dbdcfae268028bfebc15c105c9721f427b0e5e358d902614898aa60fe8a7cc779e84bd98246631dc374654c8b910b05307988290801e2b7b23642a394fe3b1
+"@pagerduty/backstage-plugin-common@npm:^0.0.1-next.11":
+  version: 0.0.1-next.11
+  resolution: "@pagerduty/backstage-plugin-common@npm:0.0.1-next.11"
+  checksum: 73abbb7e5b936fe0b41d7d2da52743e72ea099e7ed19d29ccfe8dac90c431f4ed86bd3bfe4fcc03577701673fd2ea3f2e07ae916c11e0172ab29b38ce02df03d
   languageName: node
   linkType: hard
 
@@ -4269,7 +4269,7 @@ __metadata:
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
-    "@pagerduty/backstage-plugin-common": ^0.0.1-next.10
+    "@pagerduty/backstage-plugin-common": ^0.0.1-next.11
     "@testing-library/dom": ^8.0.0
     "@testing-library/jest-dom": ^5.10.1
     "@testing-library/react": ^12.1.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,10 +4242,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagerduty/backstage-plugin-common@npm:^0.0.1-next.12":
-  version: 0.0.1-next.12
-  resolution: "@pagerduty/backstage-plugin-common@npm:0.0.1-next.12"
-  checksum: 38215f6af8bf7ea21a056ed8de4316356781b48d14b3f9c737dc27cb91c412f60a3c0521eb57dd50bfef7319f54b38d640b2dcbc36a4b2ace0cbd9669b20cc5e
+"@pagerduty/backstage-plugin-common@npm:^0.0.1-next.13":
+  version: 0.0.1-next.13
+  resolution: "@pagerduty/backstage-plugin-common@npm:0.0.1-next.13"
+  checksum: 8ee8799cc44c322e5c54a2734a132b3cf5e70f6d97e8fe6e7ab144e2d6977c7100bbcb4eed1946c13a07492e54b2dfe9c42467aed7d2e55576ebc7d64f84c53b
   languageName: node
   linkType: hard
 
@@ -4269,7 +4269,7 @@ __metadata:
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
-    "@pagerduty/backstage-plugin-common": ^0.0.1-next.12
+    "@pagerduty/backstage-plugin-common": ^0.0.1-next.13
     "@testing-library/dom": ^8.0.0
     "@testing-library/jest-dom": ^5.10.1
     "@testing-library/react": ^12.1.3
@@ -4287,7 +4287,7 @@ __metadata:
     react-use: ^17.2.4
     typescript: ^4.8.4
   peerDependencies:
-    "@pagerduty/backstage-plugin-common": ^0.0.1-next.12
+    "@pagerduty/backstage-plugin-common": ^0.0.1-next.13
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,10 +4242,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagerduty/backstage-plugin-common@npm:^0.0.1-next.7":
-  version: 0.0.1-next.7
-  resolution: "@pagerduty/backstage-plugin-common@npm:0.0.1-next.7"
-  checksum: 221f3987ff2064e99a03046f56fa4f871c66f6e9abf8b3ceb5ac95894566927ce833ccde155ff41d29e452a46c105f8e275b33c37c71592c5cbf4f8d08ff8ea6
+"@pagerduty/backstage-plugin-common@npm:^0.0.1-next.8":
+  version: 0.0.1-next.8
+  resolution: "@pagerduty/backstage-plugin-common@npm:0.0.1-next.8"
+  checksum: 869235a41b200dadf2ffff2dfc052a649b7f12a9bce149f9a30bbba5d7ad3b939c75148e39867570422cbb4839ab6f847ad0bf9dfe516a189127fc80a3c9f8e6
   languageName: node
   linkType: hard
 
@@ -4269,7 +4269,7 @@ __metadata:
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
-    "@pagerduty/backstage-plugin-common": ^0.0.1-next.7
+    "@pagerduty/backstage-plugin-common": ^0.0.1-next.8
     "@testing-library/dom": ^8.0.0
     "@testing-library/jest-dom": ^5.10.1
     "@testing-library/react": ^12.1.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,6 +4242,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@pagerduty/backstage-plugin-common@npm:^0.0.1-next.7":
+  version: 0.0.1-next.7
+  resolution: "@pagerduty/backstage-plugin-common@npm:0.0.1-next.7"
+  checksum: 221f3987ff2064e99a03046f56fa4f871c66f6e9abf8b3ceb5ac95894566927ce833ccde155ff41d29e452a46c105f8e275b33c37c71592c5cbf4f8d08ff8ea6
+  languageName: node
+  linkType: hard
+
 "@pagerduty/backstage-plugin@workspace:.":
   version: 0.0.0-use.local
   resolution: "@pagerduty/backstage-plugin@workspace:."
@@ -4262,6 +4269,7 @@ __metadata:
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
+    "@pagerduty/backstage-plugin-common": ^0.0.1-next.7
     "@testing-library/dom": ^8.0.0
     "@testing-library/jest-dom": ^5.10.1
     "@testing-library/react": ^12.1.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,10 +4242,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagerduty/backstage-plugin-common@npm:^0.0.1-next.11":
-  version: 0.0.1-next.11
-  resolution: "@pagerduty/backstage-plugin-common@npm:0.0.1-next.11"
-  checksum: 73abbb7e5b936fe0b41d7d2da52743e72ea099e7ed19d29ccfe8dac90c431f4ed86bd3bfe4fcc03577701673fd2ea3f2e07ae916c11e0172ab29b38ce02df03d
+"@pagerduty/backstage-plugin-common@npm:^0.0.1-next.12":
+  version: 0.0.1-next.12
+  resolution: "@pagerduty/backstage-plugin-common@npm:0.0.1-next.12"
+  checksum: 38215f6af8bf7ea21a056ed8de4316356781b48d14b3f9c737dc27cb91c412f60a3c0521eb57dd50bfef7319f54b38d640b2dcbc36a4b2ace0cbd9669b20cc5e
   languageName: node
   linkType: hard
 
@@ -4269,7 +4269,7 @@ __metadata:
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
-    "@pagerduty/backstage-plugin-common": ^0.0.1-next.11
+    "@pagerduty/backstage-plugin-common": ^0.0.1-next.12
     "@testing-library/dom": ^8.0.0
     "@testing-library/jest-dom": ^5.10.1
     "@testing-library/react": ^12.1.3
@@ -4287,6 +4287,7 @@ __metadata:
     react-use: ^17.2.4
     typescript: ^4.8.4
   peerDependencies:
+    "@pagerduty/backstage-plugin-common": ^0.0.1-next.12
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,10 +4242,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagerduty/backstage-plugin-common@npm:^0.0.1-next.8":
-  version: 0.0.1-next.8
-  resolution: "@pagerduty/backstage-plugin-common@npm:0.0.1-next.8"
-  checksum: 869235a41b200dadf2ffff2dfc052a649b7f12a9bce149f9a30bbba5d7ad3b939c75148e39867570422cbb4839ab6f847ad0bf9dfe516a189127fc80a3c9f8e6
+"@pagerduty/backstage-plugin-common@npm:^0.0.1-next.10":
+  version: 0.0.1-next.10
+  resolution: "@pagerduty/backstage-plugin-common@npm:0.0.1-next.10"
+  checksum: 94dbdcfae268028bfebc15c105c9721f427b0e5e358d902614898aa60fe8a7cc779e84bd98246631dc374654c8b910b05307988290801e2b7b23642a394fe3b1
   languageName: node
   linkType: hard
 
@@ -4269,7 +4269,7 @@ __metadata:
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
-    "@pagerduty/backstage-plugin-common": ^0.0.1-next.8
+    "@pagerduty/backstage-plugin-common": ^0.0.1-next.10
     "@testing-library/dom": ^8.0.0
     "@testing-library/jest-dom": ^5.10.1
     "@testing-library/react": ^12.1.3


### PR DESCRIPTION
### Description

This PR moves the direct REST API calls from the frontend component to the backend. Instead of leveraging the Backstage proxy to make direct API calls to PagerDuty the calls are made now to the backend plugin. 

This removes the dependency on the proxy and prevents other plugins from using the PagerDuty proxy configuration to call PagerDuty APIs for other purposes which raises few security concerns.

This PR also fixes an issue with the on-call users not showing up (#58).

**Issue number:** #37.

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
