### PR TITLE
chore(deps): bumping up common package version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
-    "@pagerduty/backstage-plugin-common": "^0.0.1-next.13",
+    "@pagerduty/backstage-plugin-common": "^0.0.2",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
@@ -60,7 +60,7 @@
     "@backstage/test-utils": "^1.4.5",
     "@commitlint/cli": "^17.7.1",
     "@commitlint/config-conventional": "^17.7.0",
-    "@pagerduty/backstage-plugin-common": "^0.0.1-next.13",
+    "@pagerduty/backstage-plugin-common": "^0.0.2",
     "@testing-library/dom": "^8.0.0",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^12.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,10 +4242,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagerduty/backstage-plugin-common@npm:^0.0.1-next.13":
-  version: 0.0.1-next.13
-  resolution: "@pagerduty/backstage-plugin-common@npm:0.0.1-next.13"
-  checksum: 8ee8799cc44c322e5c54a2734a132b3cf5e70f6d97e8fe6e7ab144e2d6977c7100bbcb4eed1946c13a07492e54b2dfe9c42467aed7d2e55576ebc7d64f84c53b
+"@pagerduty/backstage-plugin-common@npm:^0.0.2":
+  version: 0.0.2
+  resolution: "@pagerduty/backstage-plugin-common@npm:0.0.2"
+  checksum: 6da0a9c1368748752db996fec6d676abfaf5c3cb66fcfdf1920e29ed5ee5f4a9c95b9503671217baec0dd729ac21f98d4b7e8475e7e712721566c4f8c526fb51
   languageName: node
   linkType: hard
 
@@ -4269,7 +4269,7 @@ __metadata:
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
-    "@pagerduty/backstage-plugin-common": ^0.0.1-next.13
+    "@pagerduty/backstage-plugin-common": ^0.0.2
     "@testing-library/dom": ^8.0.0
     "@testing-library/jest-dom": ^5.10.1
     "@testing-library/react": ^12.1.3
@@ -4287,7 +4287,7 @@ __metadata:
     react-use: ^17.2.4
     typescript: ^4.8.4
   peerDependencies:
-    "@pagerduty/backstage-plugin-common": ^0.0.1-next.13
+    "@pagerduty/backstage-plugin-common": ^0.0.2
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0


### PR DESCRIPTION
### Description

This PR bumps the version of @pagerduty/backstage-plugin-common to version 0.0.2. Version 0.0.1 had a misconfiguration that was forcing the backend plugin to load it as an ES6 module and while that's supported for the frontend it is not yet fully supported for backend plugins.

This upgrade syncs the version of the common package between frontend and backend plugins.

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
