### PR TITLE
Feat/add suport for scoped oauth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ tsconfig.tmp.json
 !config.d.ts
 !custom.d.ts
 .gitignore
+app-config.dev.yaml

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -44,12 +44,17 @@ integrations:
     #   token: ${GHE_TOKEN}
 pagerDuty:
   eventsBaseUrl: 'https://events.pagerduty.com/v2'
+  apiToken: ${PAGERDUTY_TOKEN}
+  oauth:
+    clientId: ${PAGERDUTY_CLIENT_ID}
+    clientSecret: ${PAGERDUTY_CLIENT_SECRET}
+    subDomain: ${PAGERDUTY_ACCOUNT}
 
-proxy:
-  '/pagerduty':
-    target: https://api.pagerduty.com
-    headers:
-      Authorization: Token token=${PAGERDUTY_TOKEN}
+# proxy:
+#   '/pagerduty':
+#     target: https://api.pagerduty.com
+#     headers:
+#       Authorization: Token token=${PAGERDUTY_TOKEN}
   ### Example for how to add a proxy endpoint for the frontend.
   ### A typical reason to do this is to handle HTTPS and CORS for internal services.
   # endpoints:

--- a/config.d.ts
+++ b/config.d.ts
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { PagerDutyOAuthConfig } from "@pagerduty/backstage-plugin-common";
+
 export interface Config {
   /**
    * Configuration for the PagerDuty plugin
@@ -29,5 +32,10 @@ export interface Config {
      * @visibility frontend
      */
     apiToken?: string;
+    /**
+     * Optional PagerDuty Scoped OAuth Token used in API calls from the backend component.
+     * @visibility frontend
+     */
+    oauth?: PagerDutyOAuthConfig;
   };
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
-    "@pagerduty/backstage-plugin-common": "^0.0.2",
+    "@pagerduty/backstage-plugin-common": "^0.1.0",
     "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "6.0.0-beta.0 || ^6.3.0"
@@ -60,7 +60,7 @@
     "@backstage/test-utils": "^1.4.5",
     "@commitlint/cli": "^17.7.1",
     "@commitlint/config-conventional": "^17.7.0",
-    "@pagerduty/backstage-plugin-common": "^0.0.2",
+    "@pagerduty/backstage-plugin-common": "^0.1.0",
     "@testing-library/dom": "^8.0.0",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^12.1.3",

--- a/src/components/ChangeEvents/ChangeEvents.test.tsx
+++ b/src/components/ChangeEvents/ChangeEvents.test.tsx
@@ -47,7 +47,7 @@ describe('Incidents', () => {
   it("Renders a forbidden state when change events is undefined", async () => {
     mockPagerDutyApi.getChangeEventsByServiceId = jest
       .fn()
-      .mockImplementationOnce(async () => {throw new Error("Forbidden: You allowed to perform this action");});
+      .mockImplementationOnce(async () => {throw new Error("Forbidden: You are not allowed to perform this action");});
 
     const { getByText, queryByTestId } = render(
       wrapInTestApp(

--- a/src/components/EntityPagerDutyCard/index.test.tsx
+++ b/src/components/EntityPagerDutyCard/index.test.tsx
@@ -199,8 +199,8 @@ describe('EntityPagerDutyCard', () => {
 
     expect(
       getByText(
-        'Error encountered while fetching information. An error occurred',
-      ),
+        "You don't have the required permissions to perform this action. See README for more details."
+      )
     ).toBeInTheDocument();
   });
 
@@ -305,8 +305,8 @@ describe('EntityPagerDutyCard', () => {
 
       expect(
         getByText(
-          'Error encountered while fetching information. An error occurred',
-        ),
+          "You don't have the required permissions to perform this action. See README for more details."
+        )
       ).toBeInTheDocument();
     });
 

--- a/src/components/Errors/ForbiddenError.tsx
+++ b/src/components/Errors/ForbiddenError.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// eslint-disable-next-line @backstage/no-undeclared-imports
+import React from 'react';
+import { Button } from '@material-ui/core';
+import { EmptyState } from '@backstage/core-components';
+
+export const ForbiddenError = () => (
+  <EmptyState
+    missing="info"
+    title="Unauthorized"
+    description="You don't have the required permissions to perform this action. See README for more details."
+    action={
+      <Button
+        color="primary"
+        variant="contained"
+        href="https://pagerduty.github.io/backstage-plugin-docs/getting-started/pagerduty/"
+      >
+        Read More
+      </Button>
+    }
+  />
+);

--- a/src/components/Escalation/Escalation.test.tsx
+++ b/src/components/Escalation/Escalation.test.tsx
@@ -46,6 +46,30 @@ describe("Escalation", () => {
     expect(mockPagerDutyApi.getOnCallByPolicyId).toHaveBeenCalledWith("456");
   });
 
+  it("Renders a forbidden state when change events is undefined", async () => {
+    mockPagerDutyApi.getOnCallByPolicyId = jest
+      .fn()
+      .mockImplementationOnce(async () => {
+        throw new Error(
+          "Forbidden: You are not allowed to perform this action"
+        );
+      });
+
+    const { getByText, queryByTestId } = render(
+      wrapInTestApp(
+        <ApiProvider apis={apis}>
+          <EscalationPolicy policyId="abc" />
+        </ApiProvider>
+      )
+    );
+    await waitFor(() => !queryByTestId("progress"));
+    expect(
+      getByText(
+        "You don't permissions to list on-calls. Check your OAuth token permissions."
+      )
+    ).toBeInTheDocument();
+  });
+
   it("Render a list of users", async () => {
     mockPagerDutyApi.getOnCallByPolicyId = jest
       .fn()

--- a/src/components/Escalation/EscalationPolicy.tsx
+++ b/src/components/Escalation/EscalationPolicy.tsx
@@ -17,6 +17,7 @@
 import React from 'react';
 import { List, ListSubheader } from '@material-ui/core';
 import { EscalationUsersEmptyState } from './EscalationUsersEmptyState';
+import { EscalationUsersForbiddenState } from './EscalationUsersForbiddenState';
 import { EscalationUser } from './EscalationUser';
 import useAsync from 'react-use/lib/useAsync';
 import { pagerDutyApiRef } from '../../api';
@@ -41,6 +42,14 @@ export const EscalationPolicy = ({ policyId }: Props) => {
   });
 
   if (error) {
+    if (error.message.includes("Forbidden")) {
+      return (
+        <List dense subheader={<ListSubheader>ON CALL</ListSubheader>}>
+          <EscalationUsersForbiddenState />
+        </List>
+      );
+    }
+
     return (
       <Alert severity="error">
         Error encountered while fetching information. {error.message}

--- a/src/components/Escalation/EscalationUsersForbiddenState.tsx
+++ b/src/components/Escalation/EscalationUsersForbiddenState.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// eslint-disable-next-line @backstage/no-undeclared-imports
+import React from 'react';
+import {
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  makeStyles,
+} from '@material-ui/core';
+import { StatusError } from '@backstage/core-components';
+
+const useStyles = makeStyles({
+  denseListIcon: {
+    marginRight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});
+
+export const EscalationUsersForbiddenState = () => {
+  const classes = useStyles();
+  return (
+    <ListItem>
+      <ListItemIcon>
+        <div className={classes.denseListIcon}>
+          <StatusError />
+        </div>
+      </ListItemIcon>
+      <ListItemText primary="You don't permissions to list on-calls. Check your OAuth token permissions." />
+    </ListItem>
+  );
+};

--- a/src/components/Incident/IncidentForbiddenState.tsx
+++ b/src/components/Incident/IncidentForbiddenState.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// eslint-disable-next-line @backstage/no-undeclared-imports
+import React from 'react';
+import { Grid, Typography } from '@material-ui/core';
+import ForbiddenStateImage from '../../assets/forbiddenstate.svg';
+
+export const IncidentForbiddenState = () => {
+  return (
+    <Grid container justify="center" direction="column" alignItems="center">
+      <Grid item xs={12}>
+        <Typography variant="h5">Feature not available with your account or token.</Typography>
+      </Grid>
+      <Grid item xs={12}>
+        <img
+          src={ForbiddenStateImage}
+          alt="ForbiddenState"
+          data-testid="forbiddenStateImg"
+        />
+      </Grid>
+    </Grid>
+  );
+};

--- a/src/components/Incident/Incidents.test.tsx
+++ b/src/components/Incident/Incidents.test.tsx
@@ -44,6 +44,26 @@ describe('Incidents', () => {
     expect(screen.getByText('Nice! No incidents found!')).toBeInTheDocument();
   });
 
+  it("Renders a forbidden state when incidents is undefined", async () => {
+    mockPagerDutyApi.getIncidentsByServiceId = jest
+      .fn()
+      .mockImplementationOnce(async () => {
+        throw new Error("Forbidden: You are not allowed to perform this action");
+      });
+
+    const { getByText, queryByTestId } = render(
+      wrapInTestApp(
+        <ApiProvider apis={apis}>
+          <Incidents serviceId="abc" refreshIncidents={false} />
+        </ApiProvider>
+      )
+    );
+    await waitFor(() => !queryByTestId("progress"));
+    expect(
+      getByText("Feature not available with your account or token.")
+    ).toBeInTheDocument();
+  });
+
   it('Renders all incidents', async () => {
     mockPagerDutyApi.getIncidentsByServiceId = jest
       .fn()

--- a/src/components/Incident/Incidents.tsx
+++ b/src/components/Incident/Incidents.tsx
@@ -24,6 +24,7 @@ import { Alert } from '@material-ui/lab';
 
 import { useApi } from '@backstage/core-plugin-api';
 import { Progress } from '@backstage/core-components';
+import { IncidentForbiddenState } from './IncidentForbiddenState';
 
 type Props = {
   serviceId: string;
@@ -47,6 +48,10 @@ export const Incidents = ({ serviceId, refreshIncidents }: Props) => {
   }, [refreshIncidents, getIncidents]);
 
   if (error) {
+    if (error.message.includes('Forbidden')) {
+      return <IncidentForbiddenState />;
+    }
+
     return (
       <Alert severity="error">
         Error encountered while fetching information. {error.message}

--- a/src/components/PagerDutyCard/index.test.tsx
+++ b/src/components/PagerDutyCard/index.test.tsx
@@ -114,8 +114,8 @@ describe('PagerDutyCard', () => {
 
     expect(
       getByText(
-        'Error encountered while fetching information. An error occurred',
-      ),
+        "You don't have the required permissions to perform this action. See README for more details."
+      )
     ).toBeInTheDocument();
   });
 
@@ -222,7 +222,7 @@ describe('PagerDutyCard', () => {
 
       expect(
         getByText(
-          'Error encountered while fetching information. An error occurred',
+          "You don't have the required permissions to perform this action. See README for more details.",
         ),
       ).toBeInTheDocument();
     });

--- a/src/components/PagerDutyCard/index.tsx
+++ b/src/components/PagerDutyCard/index.tsx
@@ -19,7 +19,6 @@ import { Card, CardHeader, Divider, CardContent } from '@material-ui/core';
 import { Incidents } from '../Incident';
 import { EscalationPolicy } from '../Escalation';
 import useAsync from 'react-use/lib/useAsync';
-import { Alert } from '@material-ui/lab';
 import { pagerDutyApiRef, UnauthorizedError } from '../../api';
 import AlarmAddIcon from '@material-ui/icons/AlarmAdd';
 import { MissingTokenError, ServiceNotFoundError } from '../Errors';
@@ -39,6 +38,7 @@ import {
   InfoCard,
 } from '@backstage/core-components';
 import { PagerDutyEntity } from '../../types';
+import { ForbiddenError } from '../Errors/ForbiddenError';
 
 const BasicCard = ({ children }: { children: ReactNode }) => (
   <InfoCard title="PagerDuty">{children}</InfoCard>
@@ -100,11 +100,7 @@ export const PagerDutyCard = (props: PagerDutyCardProps) => {
         errorNode = <ServiceNotFoundError />;
         break;
       default:
-        errorNode = (
-          <Alert severity="error">
-            Error encountered while fetching information. {error.message}
-          </Alert>
-        );
+        errorNode = <ForbiddenError />;
     }
 
     return <BasicCard>{errorNode}</BasicCard>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4242,10 +4242,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagerduty/backstage-plugin-common@npm:^0.0.2":
-  version: 0.0.2
-  resolution: "@pagerduty/backstage-plugin-common@npm:0.0.2"
-  checksum: 6da0a9c1368748752db996fec6d676abfaf5c3cb66fcfdf1920e29ed5ee5f4a9c95b9503671217baec0dd729ac21f98d4b7e8475e7e712721566c4f8c526fb51
+"@pagerduty/backstage-plugin-common@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@pagerduty/backstage-plugin-common@npm:0.1.0"
+  checksum: a16768493e91895f67d41d785a79b580d5b00055fb44daedbed81732a43790d8cb884923dbcc8e7c020cf5d3f772d73eb067705c68736863974be80703499041
   languageName: node
   linkType: hard
 
@@ -4269,7 +4269,7 @@ __metadata:
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
-    "@pagerduty/backstage-plugin-common": ^0.0.2
+    "@pagerduty/backstage-plugin-common": ^0.1.0
     "@testing-library/dom": ^8.0.0
     "@testing-library/jest-dom": ^5.10.1
     "@testing-library/react": ^12.1.3
@@ -4287,7 +4287,7 @@ __metadata:
     react-use: ^17.2.4
     typescript: ^4.8.4
   peerDependencies:
-    "@pagerduty/backstage-plugin-common": ^0.0.2
+    "@pagerduty/backstage-plugin-common": ^0.1.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0


### PR DESCRIPTION
### Description

This PR adds the type necessary for OAuth support in Backstage plugin configuration. Users can now configure the following OAuth parameters in Backstage `app-config.yaml` file.

```yaml
pagerDuty:
  oauth:
    clientId: ${PD_CLIENT_ID}
    clientSecret: ${PD_CLIENT_SECRET}
    subDomain: ${PD_ACCOUNT_SUBDOMAIN}
    region: ${PD_ACCOUNT_REGION}           // Optional. allowed values: 'us', 'eu'. Defaults to 'us'.
```

It also introduces more friendly error messages when permissions for certain APIs or operations are not present. 

**Issue number:** #53 

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
