### PR TITLE
fix: updating config schema to allow overriding of api base url

### DIFF
--- a/config.d.ts
+++ b/config.d.ts
@@ -28,6 +28,11 @@ export interface Config {
      */
     eventsBaseUrl?: string;
     /**
+         * Optional API Base URL to override the default.
+         * @visibility frontend
+         */
+    apiBaseUrl?: string;
+    /**
      * Optional PagerDuty API Token used in API calls from the backend component.
      * @visibility frontend
      */


### PR DESCRIPTION
### Description

This PR resolves an issue reported in backstage-plugin (#74) which prevents users from overriding the REST API base url (e.g. for EU based accounts). This feature was possible through the Backstage proxy configuration.

With this, users will be able to add a new configuration to the PagerDuty plugin in `app-config.yaml` like the example below. 

```yaml
pagerDuty:
  apiBaseUrl: https://api.eu.pagerduty.com     #defaults to https://api.pagerduty.com
```

This feature in mainly implemented in `@pagerduty/backstage-plugin-backend` but this PR updates the plugin config schema accordingly.

**Issue number:** #74

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
