### PR TITLE
fix: remove config definitions that are secret

### DIFF
--- a/config.d.ts
+++ b/config.d.ts
@@ -32,15 +32,5 @@ export interface Config {
          * @visibility frontend
          */
     apiBaseUrl?: string;
-    /**
-     * Optional PagerDuty API Token used in API calls from the backend component.
-     * @visibility frontend
-     */
-    apiToken?: string;
-    /**
-     * Optional PagerDuty Scoped OAuth Token used in API calls from the backend component.
-     * @visibility frontend
-     */
-    oauth?: PagerDutyOAuthConfig;
   };
 }


### PR DESCRIPTION
### Description

Removes the `pagerDuty.apiToken` and `pagerDuty.oauth` configuration definitions from this repository as they should be treated as secret config and this frontend plugin does not need to know about them.

See https://github.com/PagerDuty/backstage-plugin-backend/pull/36 for a related PR to mark those configuration values as secret.

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
