### PR TITLE
feat: hide trigger incident on missing integration key

### DIFF
--- a/src/components/EntityPagerDutyCard/index.test.tsx
+++ b/src/components/EntityPagerDutyCard/index.test.tsx
@@ -282,7 +282,7 @@ describe("EntityPagerDutyCard", () => {
       );
       await waitFor(() => !queryByTestId("progress"));
       expect(getByText("Open service in PagerDuty")).toBeInTheDocument();
-      expect(getByText("Create new incident")).toBeInTheDocument();
+      expect(queryByTestId("trigger-incident-button")).not.toBeInTheDocument();
       expect(getByText("Nice! No incidents found!")).toBeInTheDocument();
       expect(
         getByText("No one is on-call. Update the escalation policy.")
@@ -349,12 +349,12 @@ describe("EntityPagerDutyCard", () => {
       ).toBeInTheDocument();
     });
 
-    it("disables the Create new incident button", async () => {
+    it("hides the Create new incident button", async () => {
       mockPagerDutyApi.getServiceByPagerDutyEntity = jest
         .fn()
         .mockImplementationOnce(async () => ({ service }));
 
-      const { queryByTestId, getByLabelText } = render(
+      const { queryByTestId } = render(
         wrapInTestApp(
           <ApiProvider apis={apis}>
             <EntityProvider entity={entityWithServiceId}>
@@ -364,7 +364,7 @@ describe("EntityPagerDutyCard", () => {
         )
       );
       await waitFor(() => !queryByTestId("progress"));
-      expect(getByLabelText("create-incident").className).toMatch("disabled");
+      expect(queryByTestId("trigger-incident-button")).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/PagerDutyCard/StatusCard.tsx
+++ b/src/components/PagerDutyCard/StatusCard.tsx
@@ -124,7 +124,7 @@ function StatusCard({ serviceId, refreshStatus }: Props) {
     <Card className={cardStyle}>
       {status !== undefined ? (
         <Typography className={largeTextStyle}>
-          {labelFromStatus(status!)}
+          {labelFromStatus(status)}
         </Typography>
       ) : (
         <Typography className={largeTextStyle}>Unable to get status</Typography>

--- a/src/components/PagerDutyCard/index.test.tsx
+++ b/src/components/PagerDutyCard/index.test.tsx
@@ -265,12 +265,12 @@ describe("PagerDutyCard", () => {
       ).toBeInTheDocument();
     });
 
-    it("disables the Create new incident button", async () => {
+    it("hides the Create new incident button", async () => {
       mockPagerDutyApi.getServiceByPagerDutyEntity = jest
         .fn()
         .mockImplementationOnce(async () => ({ service }));
 
-      const { queryByTestId, getByLabelText } = render(
+      const { queryByTestId } = render(
         wrapInTestApp(
           <ApiProvider apis={apis}>
             <PagerDutyCard name="blah" serviceId="def123" />
@@ -278,7 +278,7 @@ describe("PagerDutyCard", () => {
         )
       );
       await waitFor(() => !queryByTestId("progress"));
-      expect(getByLabelText("create-incident").className).toMatch("disabled");
+      expect(queryByTestId("trigger-incident-button")).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/PagerDutyCard/index.tsx
+++ b/src/components/PagerDutyCard/index.tsx
@@ -191,9 +191,10 @@ export const PagerDutyCard = (props: PagerDutyCardProps) => {
           )
         }
         action={
-          !readOnly ? (
+          (!readOnly && props.integrationKey) ? (
             <div>
               <TriggerIncidentButton
+                data-testid="trigger-incident-button"
                 integrationKey={props.integrationKey}
                 entityName={props.name}
                 handleRefresh={handleRefresh}
@@ -236,7 +237,7 @@ export const PagerDutyCard = (props: PagerDutyCardProps) => {
             <InsightsCard
               count={
                 service?.metrics !== undefined && service.metrics.length > 0
-                  ? service?.metrics![0].total_interruptions
+                  ? service?.metrics[0].total_interruptions
                   : undefined
               }
               label="interruptions"
@@ -247,7 +248,7 @@ export const PagerDutyCard = (props: PagerDutyCardProps) => {
             <InsightsCard
               count={
                 service?.metrics !== undefined && service.metrics.length > 0
-                  ? service?.metrics![0].total_high_urgency_incidents
+                  ? service?.metrics[0].total_high_urgency_incidents
                   : undefined
               }
               label="high urgency"
@@ -269,13 +270,11 @@ export const PagerDutyCard = (props: PagerDutyCardProps) => {
         <Grid item md={3}>
           <ServiceStandardsCard
             total={
-              service?.standards !== undefined &&
               service?.standards?.score !== undefined
                 ? service?.standards?.score?.total
                 : undefined
             }
             completed={
-              service?.standards !== undefined &&
               service?.standards?.score !== undefined
                 ? service?.standards?.score?.passing
                 : undefined


### PR DESCRIPTION
### Description

This PR introduces a behaviour change when the `integration key` is missing from an entity configuration. Currently the behaviour is to disable the button but keep it on the screen. 

After discussing the plugin with several customers, many shared with us that they don't want people to manually create incidents from Backstage as incidents are automatically created from alerts. Therefore we decided to remove the button if the integration key is not provided as part of the entity configuration, like we already do when the `readonly` parameter is passed to the PagerDutyCard.

This also allows us to save some valuable space in the PagerDutyCard.

**Issue number:** #67 

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
