### PR TITLE
feat: hide on-call information

### DIFF
--- a/src/components/EntityPagerDutyCard/index.test.tsx
+++ b/src/components/EntityPagerDutyCard/index.test.tsx
@@ -393,6 +393,54 @@ describe("EntityPagerDutyCard", () => {
     });
   });
 
+  describe("when entity has all annotations but the plugin has been configured to disable change events", () => {
+    it("must hide change events tab", async () => {
+      mockPagerDutyApi.getServiceByPagerDutyEntity = jest
+        .fn()
+        .mockImplementationOnce(async () => ({ service }));
+
+      const { getByText, queryByTestId } = render(
+        wrapInTestApp(
+          <ApiProvider apis={apis}>
+            <EntityProvider entity={entityWithAllAnnotations}>
+              <EntityPagerDutyCard disableChangeEvents />
+            </EntityProvider>
+          </ApiProvider>
+        )
+      );
+      await waitFor(() => !queryByTestId("progress"));
+      expect(getByText("Open service in PagerDuty")).toBeInTheDocument();
+      expect(queryByTestId("change-events")).not.toBeInTheDocument();
+      expect(getByText("Nice! No incidents found!")).toBeInTheDocument();
+      expect(
+        getByText("No one is on-call. Update the escalation policy.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when entity has all annotations but the plugin has been configured to disable on-call", () => {
+    it("must hide on-call component", async () => {
+      mockPagerDutyApi.getServiceByPagerDutyEntity = jest
+        .fn()
+        .mockImplementationOnce(async () => ({ service }));
+
+      const { getByText, queryByTestId } = render(
+        wrapInTestApp(
+          <ApiProvider apis={apis}>
+            <EntityProvider entity={entityWithAllAnnotations}>
+              <EntityPagerDutyCard disableOnCall />
+            </EntityProvider>
+          </ApiProvider>
+        )
+      );
+      await waitFor(() => !queryByTestId("progress"));
+      expect(getByText("Open service in PagerDuty")).toBeInTheDocument();
+      expect(getByText("Change Events")).toBeInTheDocument();
+      expect(getByText("Nice! No incidents found!")).toBeInTheDocument();
+      expect(queryByTestId("oncall-card")).not.toBeInTheDocument();
+    });
+  });
+
   describe('when entity has all annotations but the plugin has been configured to be "read only"', () => {
     it('queries by integration key but does not render the "Create new incident" button', async () => {
       mockPagerDutyApi.getServiceByPagerDutyEntity = jest

--- a/src/components/EntityPagerDutyCard/index.tsx
+++ b/src/components/EntityPagerDutyCard/index.tsx
@@ -32,11 +32,12 @@ export const isPluginApplicableToEntity = (entity: Entity) =>
 export type EntityPagerDutyCardProps = {
   readOnly?: boolean;
   disableChangeEvents?: boolean;
+  disableOnCall?: boolean;
 };
 
 /** @public */
 export const EntityPagerDutyCard = (props: EntityPagerDutyCardProps) => {
-  const { readOnly, disableChangeEvents } = props;
+  const { readOnly, disableChangeEvents, disableOnCall } = props;
   const { entity } = useEntity();
   const pagerDutyEntity = getPagerDutyEntity(entity);
   return (
@@ -44,6 +45,7 @@ export const EntityPagerDutyCard = (props: EntityPagerDutyCardProps) => {
       {...pagerDutyEntity}
       readOnly={readOnly}
       disableChangeEvents={disableChangeEvents}
+      disableOnCall={disableOnCall}
     />
   );
 };

--- a/src/components/PagerDutyCard/index.tsx
+++ b/src/components/PagerDutyCard/index.tsx
@@ -100,6 +100,7 @@ const BasicCard = ({ children }: { children: ReactNode }) => (
 export type PagerDutyCardProps = PagerDutyEntity & {
   readOnly?: boolean;
   disableChangeEvents?: boolean;
+  disableOnCall?: boolean;
 };
 
 /** @public */
@@ -107,7 +108,7 @@ export const PagerDutyCard = (props: PagerDutyCardProps) => {
   const classes = useStyles();
 
   const theme = useTheme();
-  const { readOnly, disableChangeEvents } = props;
+  const { readOnly, disableChangeEvents, disableOnCall } = props;
   const api = useApi(pagerDutyApiRef);
   const [refreshIncidents, setRefreshIncidents] = useState<boolean>(false);
   const [refreshChangeEvents, setRefreshChangeEvents] =
@@ -300,6 +301,7 @@ export const PagerDutyCard = (props: PagerDutyCardProps) => {
           {disableChangeEvents !== true ? (
             <CardTab label="Change Events">
               <ChangeEvents
+                data-testid="change-events"
                 serviceId={service!.id}
                 refreshEvents={refreshChangeEvents}
               />
@@ -308,11 +310,16 @@ export const PagerDutyCard = (props: PagerDutyCardProps) => {
             <></>
           )}
         </TabbedCard>
+        {disableOnCall !== true ? (
         <EscalationPolicy
+          data-testid="oncall-card"
           policyId={service!.policyId}
           policyUrl={service!.policyLink}
           policyName={service!.policyName}
         />
+        ) : (
+          <></>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
### Description

This PR introduces a new `PagerDutyCard` option (_disableOnCall_) that allows users to completely hide the on-call section of the card. This feature was requested by several customers. 

The on-call section will still be shown by default making this an opt-in feature.

**Issue number:** #68 

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
