### PR TITLE
fix: correct client test case description

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,12 @@ If you need help with this plugin, please open an issue in [GitHub](https://gith
 ## Contributing
 
 If you are interested in contributing to this project, please refer to our [Contributing Guidelines](https://github.com/PagerDuty/backstage-plugin/blob/main/CONTRIBUTING.md).
+
+<a href="https://next.ossinsight.io/widgets/official/compose-contributors?limit=30&repo_id=681249868" target="_blank" style="display: block" align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://next.ossinsight.io/widgets/official/compose-contributors/thumbnail.png?limit=30&repo_id=681249868&image_size=auto&color_scheme=dark" width="655" height="auto">
+    <img alt="Contributors of PagerDuty/backstage-plugin" src="https://next.ossinsight.io/widgets/official/compose-contributors/thumbnail.png?limit=30&repo_id=681249868&image_size=auto&color_scheme=light" width="655" height="auto">
+  </picture>
+</a>
+
+<!-- Made with [OSS Insight](https://ossinsight.io/) -->

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -320,7 +320,7 @@ describe('PagerDutyClient', () => {
           });
         });
 
-        it('throws NotFoundError', async () => {
+        it('throws a corresponding error', async () => {
           await expect(client.getServiceByEntity(entity)).rejects.toThrow(
             'Request failed with 500, Not valid request internal error occurred',
           );


### PR DESCRIPTION

### Description

This corrects the `it()` description associated with the PagerDuty API client's handling of generic non-OK HTTP responses that are not 401s, 403s, or 404s. Previously, the test case claimed the client throws `NotFoundError`s in such cases. This is not true; the client throws a generic descriptive error in such cases.

Thanks!

**Issue number:** (e.g. #123)

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [X] I have performed a self-review of this change
- [X] Changes have been tested
- [X] Changes are documented
- [X] Changes generate *no new warnings*
- [X] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
