### PR TITLE
fix: ensures incident description state is cleaned after an incident is triggered

### DIFF
--- a/src/components/TriggerDialog/TriggerDialog.tsx
+++ b/src/components/TriggerDialog/TriggerDialog.tsx
@@ -85,6 +85,9 @@ export const TriggerDialog = ({
           message: `Alarm successfully triggered`,
         });
 
+        // clear description state
+        setDescription("");
+
         handleDialog();
 
         // The pager duty API isn't always returning the newly created alarm immediately


### PR DESCRIPTION
### Description

This PR fixes an issue reported in #103 that was allowing users to trigger incidents without filling in the description because the state was being wrongly kept in memory.

**Issue number:** #103 

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
