### PR TITLE
fix: turned columnvisibility into a static object

### DIFF
--- a/src/components/PagerDutyPage/MappingTable.tsx
+++ b/src/components/PagerDutyPage/MappingTable.tsx
@@ -97,6 +97,7 @@ export const MappingTable = ({
     const columns = useMemo<MRT_ColumnDef<PagerDutyEntityMapping>[]>(
       () => [
         {
+          id: "serviceId",
           accessorKey: "serviceId",
           header: "Service ID",
           visibleInShowHideMenu: false,
@@ -109,6 +110,7 @@ export const MappingTable = ({
           ),
         },
         {
+          id: "integrationKey",
           accessorKey: "integrationKey",
           header: "Integration Key",
           visibleInShowHideMenu: false,
@@ -116,27 +118,32 @@ export const MappingTable = ({
           Edit: () => null,
         },
         {
+          id: "serviceName",
           accessorKey: "serviceName",
           header: "PagerDuty Service",
           enableEditing: false,
         },
         {
+          id: "account",
           accessorKey: "account",
           header: "Account",
           enableEditing: false,
           Edit: () => null,
         },
         {
+          id: "team",
           accessorKey: "team",
           header: "Team",
           enableEditing: false,
         },
         {
+          id: "escalationPolicy",
           accessorKey: "escalationPolicy",
           header: "Escalation Policy",
           enableEditing: false,
         },
         {
+          id: "entityRef",
           accessorKey: "entityRef",
           header: "Mapping",
           visibleInShowHideMenu: false,
@@ -151,12 +158,14 @@ export const MappingTable = ({
           },
         },
         {
+          id: "entityName",
           accessorKey: "entityName",
           header: "Mapped Entity Name",
           enableEditing: false,
           Edit: () => null,
         },
         {
+          id: "status",
           accessorKey: "status",
           header: "Status",
           enableEditing: false,
@@ -174,6 +183,7 @@ export const MappingTable = ({
           ),
         },
         {
+          id: "serviceUrl",
           accessorKey: "serviceUrl",
           header: "Service URL",
           visibleInShowHideMenu: false,
@@ -297,6 +307,8 @@ export const MappingTable = ({
         showAlertBanner:
           mappings === undefined || catalogEntities === undefined,
         showProgressBars: mappings.length === 0 || catalogEntities.length === 0,
+      },
+      initialState: {
         columnVisibility: {
           serviceId: false,
           entityRef: false,


### PR DESCRIPTION
### Description

This PR introduces a fix to the issue reported on #123 that prevents users from showing/hiding columns in the service mapping table on `PagerDutyPage`.

**Issue number:** #123 

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
