### PR TITLE
refactor: disabled pagerduty option due to a design limitation on Backstage

### DIFF
--- a/src/components/PagerDutyPage/index.tsx
+++ b/src/components/PagerDutyPage/index.tsx
@@ -132,6 +132,7 @@ export const PagerDutyPage = () => {
                       value="pagerduty"
                       control={<Radio />}
                       label="PagerDuty"
+                      disabled
                     />
                     <FormControlLabel
                       value="both"


### PR DESCRIPTION
### Description

This PR disables PagerDuty option on service dependency syncing configuration in `PagerDutyPage`. There is a design option on Backstage that prevents us to fully replace or remove existing relations from an entity configuration file. For that reason we are not able to guarantee that proper behaviour of PagerDuty syncing to Backstage. 

Users can still choose to have Backstage as a main source, ou to use both Backstage and PagerDuty which will merge the two sets of service dependencies in both platforms and keep them in sync.

**Issue number:** N/A

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
