### PR TITLE
refactor: enable PagerDuty option on PagerDutyPage

### DIFF
--- a/src/components/PagerDutyPage/index.tsx
+++ b/src/components/PagerDutyPage/index.tsx
@@ -132,7 +132,6 @@ export const PagerDutyPage = () => {
                       value="pagerduty"
                       control={<Radio />}
                       label="PagerDuty"
-                      disabled
                     />
                     <FormControlLabel
                       value="both"


### PR DESCRIPTION
### Description

This PR enables the `PagerDuty` option in the PagerDutyPage component settings which allows users to set PagerDuty as their main source for syncing service dependencies to Backstage. 

This feature was disabled due to a limitation on version [0.3.0](https://github.com/PagerDuty/backstage-plugin-entity-processor/releases/tag/0.3.0) of `@pagerduty/backstage-plugin-entity-processor` which is now fixed and released on version [0.3.1](https://github.com/PagerDuty/backstage-plugin-entity-processor/releases/tag/0.3.1).

**Issue number:** N/A

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
