### PR TITLE
release: 0.15.1

### DIFF
--- a/src/components/PagerDutyPage/index.tsx
+++ b/src/components/PagerDutyPage/index.tsx
@@ -132,6 +132,7 @@ export const PagerDutyPage = () => {
                       value="pagerduty"
                       control={<Radio />}
                       label="PagerDuty"
+                      disabled
                     />
                     <FormControlLabel
                       value="both"

--- a/src/components/PagerDutyPage/index.tsx
+++ b/src/components/PagerDutyPage/index.tsx
@@ -132,7 +132,6 @@ export const PagerDutyPage = () => {
                       value="pagerduty"
                       control={<Radio />}
                       label="PagerDuty"
-                      disabled
                     />
                     <FormControlLabel
                       value="both"


### PR DESCRIPTION
### Description

This PR enables the `PagerDuty` option in the PagerDutyPage component settings which allows users to set PagerDuty as their main source for syncing service dependencies to Backstage. 

This feature was disabled due to a limitation on version [0.3.0](https://github.com/PagerDuty/backstage-plugin-entity-processor/releases/tag/0.3.0) of `@pagerduty/backstage-plugin-entity-processor` which is now fixed and released on version [0.3.1](https://github.com/PagerDuty/backstage-plugin-entity-processor/releases/tag/0.3.1).

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
