### PR TITLE
fix: fix pluginPackages type

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,8 +1,10 @@
 nodeLinker: node-modules
 
-npmRegistryServer: https://registry.npmjs.org/
+npmRegistryServer: "https://registry.npmjs.org/"
 
 npmScopes:
   pagerduty:
     npmAlwaysAuth: true
     npmAuthToken: NPM_TOKEN
+
+yarnPath: .yarn/releases/yarn-3.6.3.cjs

--- a/package.json
+++ b/package.json
@@ -13,15 +13,21 @@
   "backstage": {
     "role": "frontend-plugin",
     "pluginId": "pagerduty",
-    "pluginPackages": "pagerduty"
+    "pluginPackages": [
+      "@pagerduty/backstage-plugin",
+      "@pagerduty/backstage-plugin-common",
+      "@pagerduty/backstage-plugin-backend"
+    ]
   },
   "homepage": "https://github.com/pagerduty/backstage-plugin",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pagerduty/backstage-plugin.git"
+    "url": "https://github.com/pagerduty/backstage-plugin.git",
+    "directory": "."
   },
   "keywords": [
     "backstage",
+    "plugin",
     "pagerduty"
   ],
   "scripts": {


### PR DESCRIPTION
### Description

The value of `backstage.pluginPackages` was incorrectly set to `pluginId` when it is supposed to represent all the packages that are a part of this plugin. This PR corrects this value and fixes an issue that prevents this plugin from being installed on certain backstage installations.

**Issue number:** N/A

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
