### PR TITLE
fix: relax version pinning of @pagerduty/backstage-plugin-common

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@mui/icons-material": "^5.15.19",
     "@mui/material": "^5.15.19",
     "@mui/x-date-pickers": "^7.6.1",
-    "@pagerduty/backstage-plugin-common": "0.2.1",
+    "@pagerduty/backstage-plugin-common": "^0.2.1",
     "@tanstack/react-query": "^5.40.1",
     "classnames": "^2.2.6",
     "luxon": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4393,7 +4393,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagerduty/backstage-plugin-common@npm:0.2.1":
+"@pagerduty/backstage-plugin-common@npm:^0.2.1":
   version: 0.2.1
   resolution: "@pagerduty/backstage-plugin-common@npm:0.2.1"
   checksum: 76233c2162d8e7bd3479e13652042cf949911be065f0bf92c5823cbc03c122b8ff49938ca36ab8449da800de7dd9c85724f70e3ff5323e77ef879478394115c9
@@ -4425,7 +4425,7 @@ __metadata:
     "@mui/icons-material": ^5.15.19
     "@mui/material": ^5.15.19
     "@mui/x-date-pickers": ^7.6.1
-    "@pagerduty/backstage-plugin-common": 0.2.1
+    "@pagerduty/backstage-plugin-common": ^0.2.1
     "@tanstack/react-query": ^5.40.1
     "@testing-library/dom": ^8.0.0
     "@testing-library/jest-dom": ^5.10.1


### PR DESCRIPTION
### Description

In order to reduce the amount changes required to update dependent packages
relax the version requirements for @pagerduty/backstage-plugin-common

**Issue number:** N/A

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
